### PR TITLE
32 version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add changelog
-- Add a new environment variable `VESYLA_SUITE_PATH_TMP` to store the temporary files. It is initialized in vs-entry. Note that, all temporary files are stored this directory should have some random name to avoid conflicts with other files.
 - Added version numbers for all tools
 
 ### Fixed
 
 ### Changed
 
+- `--version` subcommand now also shows the versions of vesyla tools
+
+### Removed
+
+## [4.0.8] - 2023-04-14
+
+### Added
+
+- Add changelog
+- Add a new environment variable `VESYLA_SUITE_PATH_TMP` to store the temporary files. It is initialized in vs-entry. Note that, all temporary files are stored this directory should have some random name to avoid conflicts with other files.
+
+### Fixed
+
+- Fix bug: report error when component is not found in library.
+
+### Changed
+
 - Modify the vs-entry to read the version from the changelog to automatically determine the software version.
 - Modify the vs-schedule to use VESYLA_SUITE_PATH_TMP to store the temporary files.
-- `--version` subcommand now also shows the versions of vesyla tools
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add changelog
 - Add a new environment variable `VESYLA_SUITE_PATH_TMP` to store the temporary files. It is initialized in vs-entry. Note that, all temporary files are stored this directory should have some random name to avoid conflicts with other files.
+- Added version numbers for all tools
 
 ### Fixed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Modify the vs-entry to read the version from the changelog to automatically determine the software version.
 - Modify the vs-schedule to use VESYLA_SUITE_PATH_TMP to store the temporary files.
+- `--version` subcommand now also shows the versions of vesyla tools
 
 ### Removed
 

--- a/module/vs-schedule/src/main.py
+++ b/module/vs-schedule/src/main.py
@@ -5,19 +5,36 @@ import logging
 import time
 import dispatch
 
+
 def main(args):
     # record the start time
     start_time = time.time()
 
     # define logging format
-    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
 
     # parse the arguments
-    parser = argparse.ArgumentParser(description='vs-schedule')
-    parser.add_argument('-p', '--proto_asm', type=str, help='proto assembly file', required=True)
-    parser.add_argument('-c', '--constraint', type=str, help='constraint file', required=True)
-    parser.add_argument('-a', '--arch', type=str, help='architecture file', required=True)
-    parser.add_argument('-o', '--output', type=str, help='output directory', default='.')
+    parser = argparse.ArgumentParser(description="vs-schedule")
+    parser.add_argument(
+        "-p", "--proto_asm", type=str, help="proto assembly file", required=True
+    )
+    parser.add_argument(
+        "-c", "--constraint", type=str, help="constraint file", required=True
+    )
+    parser.add_argument(
+        "-a", "--arch", type=str, help="architecture file", required=True
+    )
+    parser.add_argument(
+        "-o", "--output", type=str, help="output directory", default="."
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 0.1.0",
+        help="show version and exit",
+    )
     args = parser.parse_args(args)
 
     # if output directory does not exist, create it
@@ -26,23 +43,24 @@ def main(args):
 
     # check file exist
     if not os.path.exists(args.proto_asm):
-            logging.error("proto_asm file does not exist")
-            sys.exit(1)
+        logging.error("proto_asm file does not exist")
+        sys.exit(1)
     if not os.path.exists(args.constraint):
-            logging.error("constraint file does not exist")
-            sys.exit(1)
+        logging.error("constraint file does not exist")
+        sys.exit(1)
     if not os.path.exists(args.arch):
-            logging.error("architecture file does not exist")
-            sys.exit(1)
-    
+        logging.error("architecture file does not exist")
+        sys.exit(1)
+
     dispatch.dispatch(args.proto_asm, args.constraint, args.arch, args.output)
-    
+
     # record the end time
     end_time = time.time()
-    
+
     # write the execution time to the log file
     with open(os.path.join(args.output, "time.txt"), "w") as file:
-        file.write(str(end_time-start_time)+"\n")
+        file.write(str(end_time - start_time) + "\n")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main(sys.argv[1:])

--- a/module/vs-testcase/Cargo.toml
+++ b/module/vs-testcase/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 # Dependencies can be added here. For example:
 [dependencies]
+clap = { version = "4.5.21", features = ["derive"] }
 log = "0.4.14"
 env_logger = "0.10.0"
 argparse = "0.2.0"

--- a/module/vs-testcase/src/main.rs
+++ b/module/vs-testcase/src/main.rs
@@ -6,7 +6,6 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process;
 
-use argparse;
 use chrono::Local;
 use clap::{Parser, Subcommand};
 use glob::glob;
@@ -69,7 +68,7 @@ fn main() {
             output,
         } => {
             info!("Initializing ...");
-            init(vec![style.clone(), force.to_string(), output.clone()])
+            init(style.clone(), *force, output.clone());
         }
         Command::Run { test_dir } => {
             info!("Running testcase ...");
@@ -109,28 +108,7 @@ fn export(args: Vec<String>) {
     copy_dir_all(&vesyla_suite_path_testcase, output_dir).unwrap();
 }
 
-fn init(args: Vec<String>) {
-    // parse the "args" using argparse
-    // -s <style> -f -o <output directory>
-    let mut style = String::from("drra");
-    let mut force = false;
-    let mut output = String::from(".");
-    {
-        let mut ap = argparse::ArgumentParser::new();
-        ap.set_description("Initialize testcase directory");
-        ap.refer(&mut style)
-            .add_option(&["-s", "--style"], argparse::Store, "Template style");
-        ap.refer(&mut force).add_option(
-            &["-f", "--force"],
-            argparse::StoreTrue,
-            "Force initialization",
-        );
-        ap.refer(&mut output)
-            .add_option(&["-o", "--output"], argparse::Store, "Output directory");
-        ap.parse(args, &mut std::io::stdout(), &mut std::io::stderr())
-            .unwrap();
-    }
-
+fn init(style: String, force: bool, output: String) {
     // create the output directory
     if !Path::new(&output).exists() {
         fs::create_dir_all(&output).unwrap();
@@ -167,12 +145,7 @@ fn run(args: Vec<String>) {
     let test_dir = &args[1];
 
     // initialize the testcase directory
-    init(
-        vec!["init", "-f", "-s", "drra", "-o", "."]
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
-    );
+    init("drra".to_string(), true, ".".to_string());
 
     // if test_dir starts with {{VESYLA_SUITE_PATH_TESTCASE}}, replace it with the actual path
     let vesyla_suite_path_testcase =


### PR DESCRIPTION
This pull request adds tools versions to the `vesyla-suite --version` subcommand (see #32).
Added arbitrary 0.1.0 version numbers to previously non-numbered tools (e.g., testcase).

_Tools versions numbers can be independent, but vesyla version number must advance when a tool is updated._