### PR TITLE
changed workflow ubuntu version from 24.04 to 22.04 

### DIFF
--- a/.github/workflows/create_release_appimage.yml
+++ b/.github/workflows/create_release_appimage.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Upload Release Asset
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [4.0.11] - 2025-04-18
+### Changed
+- [github workflow] changed ubuntu version from 24.04 to 22.04 to improve compatibility for older devices
+
 ## [4.0.10] - 2025-04-17
 ### Fixed
 - [vs-component] fixed error where the assembly would fail when overwriting custom_properties


### PR DESCRIPTION
changed workflow ubuntu version from 24.04 to 22.04 to lower the requirements of vesyla-suite libc version

ubuntu 24.04 uses GLIBC 2.39
ubuntu 22.04 uses GLIBC 2.35

as GLIBC is backwards compatible, let's use the oldest version available on GH runners, this way people with GLIBC 2.35 and above can directly download and run the release without compatibility issues

This change is also needed to fix https://github.com/silagokth/drra-components/issues/39