### PR TITLE
feat: support for new drra-components folder structure

### DIFF
--- a/module/vs-component/Cargo.toml
+++ b/module/vs-component/Cargo.toml
@@ -20,7 +20,7 @@ argparse = "0.2.0"
 serde = "1.0.215"
 serde_json = "1.0.70"
 serde_yml = "0.0.12"
-minijinja = { version = "2.0.2" }
+minijinja = { version = "2.0.2" , features = ["loader"] }
 bs58 = "0.5.1"
 jsonschema = "0.26.1"
 walkdir = "2.5.0"

--- a/module/vs-component/src/utils.rs
+++ b/module/vs-component/src/utils.rs
@@ -321,6 +321,8 @@ pub fn generate_rtl_for_component(
         let rtl_template_path = Path::new(&rtl_template_str);
         if rtl_template_path.exists() {
             let mut mj_env = minijinja::Environment::new();
+            let template_dir = std::path::PathBuf::from(get_library_path()).join("common/jinja");
+            mj_env.set_loader(minijinja::path_loader(template_dir));
             mj_env.set_trim_blocks(true);
             mj_env.set_lstrip_blocks(true);
             let rtl_template_content =
@@ -328,10 +330,12 @@ pub fn generate_rtl_for_component(
             mj_env
                 .add_template("rtl_template", &rtl_template_content.as_str())
                 .expect("Failed to add template");
+
+            // Render the template with the component data
             let result = mj_env
                 .get_template("rtl_template")
                 .expect("Failed to get template")
-                .render(&component);
+                .render(component);
             let output_str = result.expect("Failed to render template");
             fs::write(&output_file, file_comment + &output_str).expect("Failed to write file");
         } else {


### PR DESCRIPTION
# Support for [drra-components](https://github.com/silagokth/drra-components) common jinja folder

## Description

[vs-component] Added support for [drra-components](https://github.com/silagokth/drra-components) common jinja folder. Templates added to this folder can be used using jinja `{% include() %}` calls.

Documentation commit: https://github.com/silagokth/SiLagoDoc/commit/febea3da06363ecb0961de96cab369814f4759f6

### Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested 

**Test Configuration**:

- OS: Ubuntu 22.04
- [drra-components](https://github.com/silagokth/drra-components): https://github.com/silagokth/drra-components/pull/58
- Other experimental setup details: I used the following testcases: https://github.com/silagokth/drra-tests/pull/2

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules