### PR TITLE
change all version to 4.2.0, remove subcommand version

### DIFF
--- a/module/vs-entry/Cargo.toml
+++ b/module/vs-entry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vs-entry"
-version = "4.1.3"
+version = "4.2.0"
 edition = "2021"
 
 # targets

--- a/module/vs-entry/src/main.rs
+++ b/module/vs-entry/src/main.rs
@@ -1,4 +1,4 @@
-use log::{error, info, warn};
+use log::{error, info};
 use std::env;
 use std::fs;
 use std::process;
@@ -59,34 +59,7 @@ fn main() {
         }
         "-V" | "--version" => {
             let version = env!("CARGO_PKG_VERSION");
-            let mut tools_versions = vec![];
-            for tool in tools_list.iter() {
-                let prog = env::var("VESYLA_SUITE_PATH_BIN").unwrap().to_string() + "/vs-" + tool;
-                let status = process::Command::new(prog)
-                    .arg("--version")
-                    .stdout(process::Stdio::piped())
-                    .stderr(process::Stdio::inherit())
-                    .output()
-                    .expect("failed to execute process");
-                if status.status.success() {
-                    let output = String::from_utf8_lossy(&status.stdout);
-                    let tool_version = output
-                        .trim()
-                        .split_whitespace()
-                        .last()
-                        .unwrap_or("Unknown")
-                        .to_string();
-                    tools_versions.push(format!("{}: {}", tool, tool_version));
-                } else {
-                    tools_versions.push(format!("{}: Unknown", tool));
-                    warn!("{:?}", status.stderr);
-                    warn!("Failed to get version for tool: {}", tool);
-                }
-            }
             info!("vesyla {}", version);
-            for tool_version in tools_versions {
-                info!(" -> {}", tool_version);
-            }
         }
         cmd if tools_list.contains(&cmd) => {
             let prog = env::var("VESYLA_SUITE_PATH_BIN").unwrap().to_string() + "/vs-" + command;

--- a/module/vs-manas/Cargo.lock
+++ b/module/vs-manas/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "vs-manas"
-version = "0.1.0"
+version = "4.2.0"
 dependencies = [
  "cfgrammar",
  "clap",

--- a/module/vs-manas/Cargo.toml
+++ b/module/vs-manas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vs-manas"
-version = "0.1.0"
+version = "4.2.0"
 edition = "2021"
 
 # targets

--- a/module/vs-testcase/Cargo.toml
+++ b/module/vs-testcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vs-testcase"
-version = "0.1.0"
+version = "4.2.0"
 edition = "2021"
 
 # targets


### PR DESCRIPTION
# change all version to 4.2.0, remove subcommand version

## Description

- Make new release version.
- Remove the version in subcommand, and replace it with the vs-entry version.

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Compile and run: vesyla -V

**Test Configuration**:

- OS:
  Fedora
- [drra-components](https://github.com/silagokth/drra-components):
  I didn't use drra-components

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
