### PR TITLE
fix: removed the second call to build appimage in the release ci

### DIFF
--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -4,11 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  ci-build-appimage:
-    uses: ./.github/workflows/ci-build-appimage.yml
-
   create_release:
-    needs: ci-build-appimage
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
# fix: removed the second call to build appimage in the release ci

## Description

The `ci-build-appimage` was called twice when the `ci-release` ran.
This is now fixed.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Untested

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
