### PR TITLE
fix(vs-component): vs-component will now print the file path if it fails parsing

### DIFF
--- a/modules/vs-component/src/rtl_code_gen.rs
+++ b/modules/vs-component/src/rtl_code_gen.rs
@@ -117,7 +117,7 @@ pub fn gen_rtl(fabric_filepath: &String, build_dir: &String, output_json: &Strin
 
     // add fabric parameters to the registry
     if fabric_object.parameters.is_empty() {
-        warn!("No fabric parameters found in {}", fabric_filepath);
+        warn!("No fabric parameters found in {:?}", fabric_filepath);
     } else {
         match add_parameters(&fabric_object.parameters, &mut parameter_list) {
             Ok(_) => (),

--- a/modules/vs-component/src/rtl_code_gen.rs
+++ b/modules/vs-component/src/rtl_code_gen.rs
@@ -77,15 +77,16 @@ pub fn gen_rtl(fabric_filepath: &String, build_dir: &String, output_json: &Strin
     let mut implemented_controllers: HashMap<String, Controller> = HashMap::new();
 
     // parse the arguments to find the fabric.json input file
-    let fabric_file = match fs::File::open(Path::new(&fabric_filepath)) {
+    let fabric_filepath = Path::new(fabric_filepath);
+    let fabric_file = match fs::File::open(&fabric_filepath) {
         Ok(file) => file,
         Err(err) => {
             println!("Error: {}", err);
-            panic!("Failed to open file: {}", fabric_filepath);
+            panic!("Failed to open file: {:?}", fabric_filepath);
         }
     };
     let fabric_json: serde_json::Value = serde_json::from_reader(fabric_file).unwrap_or_else(|e| {
-        panic!("Failed to parse fabric.json: {}", e);
+        panic!("Failed to parse file {:?}: {}", fabric_filepath, e);
     });
 
     // create a registry to store the parameters


### PR DESCRIPTION
# fix(vs-component): vs-component will now print the file path if it fails parsing

## Description

Before, vs-component would print `Failed to parse fabric.json` when failing to parse the architecture description file.
Now, it prints the actual path of the file given by the `-a ...` argument.

Fixes #73 

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Build vesyla and ran testcases from drra-tests

**Test Configuration**:

- OS: Ubuntu 22.04
- [drra-components](https://github.com/silagokth/drra-components): v2.5.3
- Other experimental setup details: N/A

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
