### PR TITLE
fix: subcommand `--help` prints the message of `--version`

### DIFF
--- a/modules/vs-component/src/main.rs
+++ b/modules/vs-component/src/main.rs
@@ -61,12 +61,16 @@ fn main() {
     let cli_args = match Args::try_parse() {
         Ok(args) => args,
         Err(e) => match e.kind() {
-            ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+            ErrorKind::DisplayVersion => {
                 println!(
                     "vesyla ({}) {}",
                     env!("CARGO_PKG_NAME"),
                     env!("VESYLA_VERSION")
                 );
+                std::process::exit(0);
+            }
+            ErrorKind::DisplayHelp => {
+                println!("{}", e);
                 std::process::exit(0);
             }
             _ => {

--- a/modules/vs-manas/src/main.rs
+++ b/modules/vs-manas/src/main.rs
@@ -37,12 +37,16 @@ fn main() {
         Err(e) => {
             // Check if the error is for displaying help or version
             match e.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+                ErrorKind::DisplayVersion => {
                     println!(
                         "vesyla ({}) {}",
                         env!("CARGO_PKG_NAME"),
                         env!("VESYLA_VERSION")
                     );
+                    process::exit(0);
+                }
+                ErrorKind::DisplayHelp => {
+                    println!("{}", e);
                     process::exit(0);
                 }
                 // For any other parsing error

--- a/modules/vs-testcase/src/main.rs
+++ b/modules/vs-testcase/src/main.rs
@@ -63,12 +63,16 @@ fn main() {
         Err(e) => {
             // Check if the error is for displaying help or version
             match e.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+                ErrorKind::DisplayVersion => {
                     println!(
                         "vesyla ({}) {}",
                         env!("CARGO_PKG_NAME"),
                         env!("VESYLA_VERSION")
                     );
+                    process::exit(0);
+                }
+                ErrorKind::DisplayHelp => {
+                    println!("{}", e);
                     process::exit(0);
                 }
                 // For any other parsing error


### PR DESCRIPTION
# fix: subcommand `--help` prints the message of `--version`

## Description

The `--help` argument for all Rust subcommands would print the `--version` message.
This is now fixed.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally

**Test Configuration**:

- OS: Ubuntu 22.04

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
