### PR TITLE
fix(vs-testcase): vsim does not find the work library when called

### DIFF
--- a/modules/vs-testcase/template/drra/script/rtl_sim.sh
+++ b/modules/vs-testcase/template/drra/script/rtl_sim.sh
@@ -40,7 +40,10 @@ cp system/instr/${id}/instr.bin temp
 cp mem/sram_image_in.bin temp
 cd temp
 bender -d ../system/rtl/tb script vsim -t sim > read_src.do
-vsim -c -voptargs=+acc -debugDB -do read_src.do -do "log * -r;run -all" work.fabric_tb
+echo "vsim -voptargs=+acc -debugDB work.fabric_tb" >> read_src.do
+echo "log * -r" >> read_src.do
+echo "run -all" >> read_src.do
+vsim -c -do read_src.do
 cd ..
 cp temp/sram_image_out.bin mem/sram_image_m3.bin
 


### PR DESCRIPTION
# fix: vsim does not find the work library when called

## Description

vsim would not find the work library when called in rtl_sim.sh
This is now fixed

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally

**Test Configuration**:

- OS: Ubuntu 22.04

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
