### PR TITLE
feat: added DRRA version to `vesyla --version`; removed subcommands `--version` argument

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "serde",
  "version_check",
@@ -95,12 +95,6 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
-name = "argparse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
 name = "autocfg"
@@ -471,17 +465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1183,15 +1166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,36 +1188,6 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -1564,7 +1508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1744,7 +1688,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -1779,12 +1723,10 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vesyla"
 version = "4.3.0"
 dependencies = [
- "argparse",
  "build-utils",
  "env_logger 0.10.2",
  "log",
  "log-panics",
- "rand",
  "regex",
 ]
 

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -57,36 +57,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -114,7 +114,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -149,9 +149,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "borrow-or-share"
@@ -174,15 +174,15 @@ version = "0.0.0"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -198,9 +198,9 @@ checksum = "acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfgrammar"
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -252,15 +252,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "deranged"
@@ -303,19 +303,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
@@ -335,12 +322,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -460,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
  "unicode-width",
 ]
@@ -487,21 +474,15 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "http"
@@ -544,12 +525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
-
-[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,17 +545,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -637,9 +616,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -653,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -712,14 +691,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
+name = "iri-string"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -842,9 +820,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -922,21 +900,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memo-map"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minijinja"
@@ -951,22 +923,22 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1079,6 +1051,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1106,15 +1084,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1137,9 +1115,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1263,9 +1241,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64",
  "bytes",
@@ -1277,11 +1255,8 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -1290,19 +1265,19 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustix"
@@ -1314,14 +1289,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1420,15 +1395,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1472,9 +1447,9 @@ checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1511,16 +1486,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1583,9 +1549,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "libc",
@@ -1606,6 +1572,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -1634,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -1655,9 +1639,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "url"
@@ -1684,11 +1668,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1724,7 +1710,7 @@ name = "vesyla"
 version = "4.3.0"
 dependencies = [
  "build-utils",
- "env_logger 0.10.2",
+ "env_logger",
  "log",
  "log-panics",
  "regex",
@@ -1746,7 +1732,7 @@ version = "0.0.0"
 dependencies = [
  "bs58",
  "clap",
- "env_logger 0.11.8",
+ "env_logger",
  "jsonschema",
  "log",
  "log-panics",
@@ -1765,7 +1751,7 @@ version = "0.0.0"
 dependencies = [
  "cfgrammar",
  "clap",
- "env_logger 0.10.2",
+ "env_logger",
  "log",
  "log-panics",
  "lrlex",
@@ -1780,7 +1766,7 @@ name = "vs-testcase"
 version = "0.0.0"
 dependencies = [
  "clap",
- "env_logger 0.10.2",
+ "env_logger",
  "log",
  "minijinja",
  "serde",
@@ -1814,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1914,42 +1900,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1958,7 +1909,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1967,7 +1918,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1976,30 +1927,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2009,22 +1944,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2033,22 +1956,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2057,22 +1968,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2081,22 +1980,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -1803,7 +1803,6 @@ name = "vs-component"
 version = "0.0.0"
 dependencies = [
  "bs58",
- "build-utils",
  "clap",
  "env_logger 0.11.8",
  "jsonschema",
@@ -1822,7 +1821,6 @@ dependencies = [
 name = "vs-manas"
 version = "0.0.0"
 dependencies = [
- "build-utils",
  "cfgrammar",
  "clap",
  "env_logger 0.10.2",
@@ -1839,7 +1837,6 @@ dependencies = [
 name = "vs-testcase"
 version = "0.0.0"
 dependencies = [
- "build-utils",
  "clap",
  "env_logger 0.10.2",
  "log",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -11,7 +11,7 @@ members = ["vs-component", "vs-testcase", "vs-manas"]
 build-utils = { path = "build-utils" }
 
 [dependencies]
-env_logger = "0.10.0"
-log = "0.4.14"
+env_logger = "0.11.8"
+log = "0.4.27"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
-regex = "1.8.5"
+regex = "1.11.1"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -11,9 +11,7 @@ members = ["vs-component", "vs-testcase", "vs-manas"]
 build-utils = { path = "build-utils" }
 
 [dependencies]
-argparse = "0.2.0"
 env_logger = "0.10.0"
 log = "0.4.14"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
-rand = "0.8.4"
 regex = "1.8.5"

--- a/modules/src/main.rs
+++ b/modules/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
     let tools_list = ["component", "manas", "schedule", "testcase"];
     match command.as_str() {
         "-h" | "--help" => {
-            info!("{}", help_message);
+            println!("{}", help_message);
             process::exit(0);
         }
         "-V" | "--version" => {
@@ -89,7 +89,7 @@ fn main() {
                 .unwrap_or_else(|_| panic!("Failed to execute command: vs-{}", command));
             if !status.success() && status.code() != Some(2) {
                 error!("{} command failed", command);
-                info!("Exit code: {}", status.code().unwrap_or(-1));
+                error!("Exit code: {}", status.code().unwrap_or(-1));
                 process::exit(status.code().unwrap_or(-1));
             }
         }

--- a/modules/src/main.rs
+++ b/modules/src/main.rs
@@ -2,6 +2,23 @@ use log::{error, info};
 use std::env;
 use std::process;
 
+fn get_drra_components_version() -> Result<String, std::io::Error> {
+    // Check if the VESYLA_SUITE_PATH_COMPONENTS environment variable is set
+    if env::var("VESYLA_SUITE_PATH_COMPONENTS").is_err() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "VESYLA_SUITE_PATH_COMPONENTS environment variable is not set",
+        ));
+    }
+
+    // Read the version file (library/VERSION)
+    let drra_components_path = env::var("VESYLA_SUITE_PATH_COMPONENTS").unwrap();
+    let version_file_path = format!("{}/VERSION", drra_components_path);
+    let version_content = std::fs::read_to_string(version_file_path)?;
+
+    Ok(version_content.trim().to_string())
+}
+
 fn main() {
     // define the used environment variables
     let name_list = vec!["VESYLA_SUITE_PATH_TESTCASE".to_string()];
@@ -48,6 +65,15 @@ fn main() {
         }
         "-V" | "--version" => {
             println!("vesyla {}", env!("VESYLA_VERSION"));
+            match get_drra_components_version() {
+                Ok(version) => {
+                    println!("drra-components {}", version);
+                }
+                Err(err) => {
+                    println!("drra-components version unknown");
+                    error!("Failed to retrieve drra-components version: {}", err);
+                }
+            }
         }
         cmd if tools_list.contains(&cmd) => {
             let current_exe = env::current_exe().unwrap();

--- a/modules/src/main.rs
+++ b/modules/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
 
     // find the directory of the current executable
     let command = &args[1];
-    let tools_list = vec!["component", "manas", "schedule", "testcase"];
+    let tools_list = ["component", "manas", "schedule", "testcase"];
     match command.as_str() {
         "-h" | "--help" => {
             info!("{}", help_message);
@@ -81,18 +81,16 @@ fn main() {
             let prog_path = current_exe_dir.join(format!("vs-{}", command));
             let prog = prog_path.to_str().unwrap();
 
-            let status = process::Command::new(&prog)
+            let status = process::Command::new(prog)
                 .args(&args[2..])
                 .stdout(process::Stdio::inherit())
                 .stderr(process::Stdio::inherit())
                 .status()
-                .expect(format!("Failed to execute command: vs-{}", command).as_str());
-            if !status.success() {
-                if status.code() != Some(2) {
-                    error!("{} command failed", command);
-                    info!("Exit code: {}", status.code().unwrap_or(-1));
-                    process::exit(status.code().unwrap_or(-1));
-                }
+                .unwrap_or_else(|_| panic!("Failed to execute command: vs-{}", command));
+            if !status.success() && status.code() != Some(2) {
+                error!("{} command failed", command);
+                info!("Exit code: {}", status.code().unwrap_or(-1));
+                process::exit(status.code().unwrap_or(-1));
             }
         }
         _ => {
@@ -122,7 +120,7 @@ fn init() {
 fn push_env(name_list: &Vec<String>) -> Vec<(String, Option<String>)> {
     let mut saved_env: Vec<(String, Option<String>)> = Vec::new();
     for name in name_list {
-        match env::var(&name) {
+        match env::var(name) {
             Ok(val) => {
                 saved_env.push((name.to_string(), Some(val)));
             }
@@ -139,10 +137,10 @@ fn pop_env(name_list: &Vec<String>, saved_env: Vec<(String, Option<String>)>) {
     for (name, val) in saved_env {
         match val {
             Some(val) => unsafe {
-                env::set_var(name.to_string(), val);
+                env::set_var(&name, val);
             },
             None => unsafe {
-                env::remove_var(name.to_string());
+                env::remove_var(&name);
             },
         }
     }

--- a/modules/vs-component/Cargo.toml
+++ b/modules/vs-component/Cargo.toml
@@ -7,9 +7,6 @@ description = "Vesyla tool to generate fabrics RTL and SST simulation configurat
 name = "vs-component"
 path = "src/main.rs"
 
-[build-dependencies]
-build-utils = { path = "../build-utils" }
-
 [dependencies]
 bs58 = "0.5.1"
 clap = { version = "4.5.21", features = ["derive"] }

--- a/modules/vs-component/Cargo.toml
+++ b/modules/vs-component/Cargo.toml
@@ -9,14 +9,14 @@ path = "src/main.rs"
 
 [dependencies]
 bs58 = "0.5.1"
-clap = { version = "4.5.21", features = ["derive"] }
+clap = { version = "4.5.40", features = ["derive"] }
 env_logger = "0.11.8"
 jsonschema = "0.30.0"
-log = "0.4.14"
+log = "0.4.27"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
-minijinja = { version = "2.0.2", features = ["loader"] }
-serde = "1.0.215"
-serde_json = "1.0.70"
+minijinja = { version = "2.10.2", features = ["loader"] }
+serde = "1.0.219"
+serde_json = "1.0.140"
 serde_yml = "0.0.12"
 svg = "0.18.0"
 tempfile = "3.20.0"

--- a/modules/vs-component/build.rs
+++ b/modules/vs-component/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    build_utils::set_git_version_env("VESYLA_VERSION");
-}

--- a/modules/vs-component/src/main.rs
+++ b/modules/vs-component/src/main.rs
@@ -8,9 +8,9 @@ mod utils;
 
 use clap::{error::ErrorKind, Parser, Subcommand};
 use log::{error, info};
+use std::fs;
 use std::io::Result;
 use std::path::Path;
-use std::{env, fs};
 
 #[derive(Subcommand)]
 enum Command {

--- a/modules/vs-component/src/main.rs
+++ b/modules/vs-component/src/main.rs
@@ -43,7 +43,7 @@ enum Command {
 }
 
 #[derive(Parser)]
-#[command(version, about, long_about=None)]
+#[command(about, long_about=None)]
 struct Args {
     /// Command to execute
     #[command(subcommand)]
@@ -61,14 +61,6 @@ fn main() {
     let cli_args = match Args::try_parse() {
         Ok(args) => args,
         Err(e) => match e.kind() {
-            ErrorKind::DisplayVersion => {
-                println!(
-                    "vesyla ({}) {}",
-                    env!("CARGO_PKG_NAME"),
-                    env!("VESYLA_VERSION")
-                );
-                std::process::exit(0);
-            }
             ErrorKind::DisplayHelp => {
                 println!("{}", e);
                 std::process::exit(0);

--- a/modules/vs-manas/Cargo.toml
+++ b/modules/vs-manas/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/main.rs"
 cfgrammar = "0.13"
 lrlex = "0.13"
 lrpar = "0.13"
-build-utils = { path = "../build-utils" }
 
 [dependencies]
 clap = { version = "4.5.21", features = ["derive"] }

--- a/modules/vs-manas/Cargo.toml
+++ b/modules/vs-manas/Cargo.toml
@@ -12,13 +12,13 @@ lrlex = "0.13"
 lrpar = "0.13"
 
 [dependencies]
-clap = { version = "4.5.21", features = ["derive"] }
-log = "0.4.14"
+clap = { version = "4.5.40", features = ["derive"] }
+log = "0.4.27"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
-env_logger = "0.10.0"
-serde = "1.0.215"
-serde_json = "1.0.70"
-uuid = { version = "1.1", features = ["v4"] }
+env_logger = "0.11.8"
+serde = "1.0.219"
+serde_json = "1.0.140"
+uuid = { version = "1.17", features = ["v4"] }
 cfgrammar = "0.13"
 lrlex = "0.13"
 lrpar = "0.13"

--- a/modules/vs-manas/build.rs
+++ b/modules/vs-manas/build.rs
@@ -2,8 +2,6 @@ use cfgrammar::yacc::YaccKind;
 use lrlex::CTLexerBuilder;
 
 fn main() {
-    build_utils::set_git_version_env("VESYLA_VERSION");
-
     CTLexerBuilder::new()
         .lrpar_config(|ctp| {
             ctp.yacckind(YaccKind::Grmtools)

--- a/modules/vs-manas/src/main.rs
+++ b/modules/vs-manas/src/main.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::process;
 
 #[derive(clappar)]
-#[command(version, about, long_about=None)]
+#[command(about, long_about=None)]
 struct Args {
     #[arg(short, long)]
     arch: String,
@@ -37,14 +37,6 @@ fn main() {
         Err(e) => {
             // Check if the error is for displaying help or version
             match e.kind() {
-                ErrorKind::DisplayVersion => {
-                    println!(
-                        "vesyla ({}) {}",
-                        env!("CARGO_PKG_NAME"),
-                        env!("VESYLA_VERSION")
-                    );
-                    process::exit(0);
-                }
                 ErrorKind::DisplayHelp => {
                     println!("{}", e);
                     process::exit(0);

--- a/modules/vs-schedule/CMakeLists.txt
+++ b/modules/vs-schedule/CMakeLists.txt
@@ -4,27 +4,13 @@ file(GLOB SRC "src/*.py")
 
 # First check if PROTOC_PATH is defined
 if(NOT DEFINED PROTOC_PATH)
-   set(PROTOC_PATH "protoc")
+  set(PROTOC_PATH "protoc")
 endif()
-
-execute_process(
-   COMMAND bash -c "git describe --tags --exact-match 2>/dev/null || git describe --always --tags"
-   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-   OUTPUT_VARIABLE VESYLA_VERSION
-   OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# If the VESYLA_VERSION value is set, write it to a file
-if(NOT VESYLA_VERSION)
-   set(VESYLA_VERSION "version unknown")
-endif()
-
-file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/src/__version__.py" "VESYLA_VERSION = \"${VESYLA_VERSION}\"\n")
 
 add_custom_command(
-   OUTPUT ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME}/dist/${CURRENT_SUBPROJECT_NAME}
-   DEPENDS ${SRC}
-   COMMAND ${PROTOC_PATH} -I=${CMAKE_CURRENT_SOURCE_DIR}/src --python_out=${CMAKE_CURRENT_SOURCE_DIR}/src ds.proto && mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} && mkdir -p ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME} && cd ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME} && pyinstaller -F -n ${CURRENT_SUBPROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src/main.py && cp -p ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME}/dist/${CURRENT_SUBPROJECT_NAME} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+  OUTPUT ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME}/dist/${CURRENT_SUBPROJECT_NAME}
+  DEPENDS ${SRC}
+  COMMAND ${PROTOC_PATH} -I=${CMAKE_CURRENT_SOURCE_DIR}/src --python_out=${CMAKE_CURRENT_SOURCE_DIR}/src ds.proto && mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} && mkdir -p ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME} && cd ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME} && pyinstaller -F -n ${CURRENT_SUBPROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src/main.py && cp -p ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME}/dist/${CURRENT_SUBPROJECT_NAME} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
 )
 
 add_custom_target(gen-${CURRENT_SUBPROJECT_NAME} ALL DEPENDS ${CMAKE_BINARY_DIR}/pyinstaller/${CURRENT_SUBPROJECT_NAME}/dist/${CURRENT_SUBPROJECT_NAME})

--- a/modules/vs-schedule/src/main.py
+++ b/modules/vs-schedule/src/main.py
@@ -5,11 +5,6 @@ import logging
 import time
 import dispatch
 
-try:
-    from __version__ import VESYLA_VERSION
-except ImportError:
-    VESYLA_VERSION = "version unknown"
-
 
 def main(args):
     # record the start time
@@ -33,12 +28,6 @@ def main(args):
     )
     parser.add_argument(
         "-o", "--output", type=str, help="output directory", default="."
-    )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version="vesyla (%(prog)s) " + VESYLA_VERSION,
-        help="show version and exit",
     )
     args = parser.parse_args(args)
 

--- a/modules/vs-testcase/Cargo.toml
+++ b/modules/vs-testcase/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2021"
 name = "vs-testcase"
 path = "src/main.rs"
 
-[build-dependencies]
-build-utils = { path = "../build-utils" }
-
 [dependencies]
 clap = { version = "4.5.21", features = ["derive"] }
 env_logger = "0.10.0"

--- a/modules/vs-testcase/Cargo.toml
+++ b/modules/vs-testcase/Cargo.toml
@@ -7,9 +7,9 @@ name = "vs-testcase"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.5.21", features = ["derive"] }
-env_logger = "0.10.0"
-log = "0.4.14"
-minijinja = { version = "2.0.2", features = ["loader"] }
-serde = { version = "1.0.215", features = ["derive"] }
+clap = { version = "4.5.40", features = ["derive"] }
+env_logger = "0.11.8"
+log = "0.4.27"
+minijinja = { version = "2.10.2", features = ["loader"] }
+serde = { version = "1.0.219", features = ["derive"] }
 tempfile = "3.20.0"

--- a/modules/vs-testcase/build.rs
+++ b/modules/vs-testcase/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    build_utils::set_git_version_env("VESYLA_VERSION");
-}

--- a/modules/vs-testcase/src/main.rs
+++ b/modules/vs-testcase/src/main.rs
@@ -56,7 +56,7 @@ enum Command {
 }
 
 #[derive(Parser)]
-#[command(version, about, long_about = None, allow_missing_positional = true, after_help = "")]
+#[command(about, long_about = None, allow_missing_positional = true, after_help = "")]
 struct Args {
     /// Command to execute
     #[command(subcommand)]
@@ -75,14 +75,6 @@ fn main() -> Result<(), io::Error> {
         Err(e) => {
             // Check if the error is for displaying help or version
             match e.kind() {
-                ErrorKind::DisplayVersion => {
-                    println!(
-                        "vesyla ({}) {}",
-                        env!("CARGO_PKG_NAME"),
-                        env!("VESYLA_VERSION")
-                    );
-                    return Ok(());
-                }
                 ErrorKind::DisplayHelp => {
                     println!("{}", e);
                     return Ok(());


### PR DESCRIPTION
# feat: added DRRA version to `vesyla --version`

**This merge request depends on https://github.com/silagokth/drra-components/pull/87 being merged first!**

## Description

- Added DRRA version to `vesyla --version` by checking for the `$VESYLA_SUITE_PATH_COMPONENTS/VERSION` file.
  - If the file is present and has a version number it will print the version number
  - If the file is not present or the env variable is not set, the version will be unknown and print an error message
- Subcommands will no longer support the `--version` argument as they follow the same version number as vesyla
- Updated cargo dependencies to latest version

### Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- Tested locally by building (`make && sudo make install`) and running cargo tests (`cd modules && cargo test --all`)

**Test Configuration**:

- OS: Ubuntu 22.04
- [drra-components](https://github.com/silagokth/drra-components): v2.5.5

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules