### PR TITLE
fix: removed cmake version parsing of Cargo.toml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC OFF)
-
-# The project version number.
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/modules/Cargo.toml" MODULES_TOML_CONTENT)
-string(REGEX MATCH "version = \"([0-9]+)\\.([0-9]+)\\.([0-9]+)\"" _ "${MODULES_TOML_CONTENT}")
-set(VERSION_MAJOR ${CMAKE_MATCH_1} CACHE STRING "Project major version number.")
-set(VERSION_MINOR ${CMAKE_MATCH_2} CACHE STRING "Project minor version number.")
-set(VERSION_PATCH ${CMAKE_MATCH_3} CACHE STRING "Project patch version number.")
-mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
-
-message(STATUS "Detected version ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH} from vs-entry")
-
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -1707,7 +1707,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesyla"
-version = "4.3.0"
+version = "0.0.0"
 dependencies = [
  "build-utils",
  "env_logger",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "vesyla"
-version = "4.3.0"
 edition = "2021"
 
 [workspace]

--- a/modules/src/main.rs
+++ b/modules/src/main.rs
@@ -1,4 +1,4 @@
-use log::{error, info};
+use log::error;
 use std::env;
 use std::process;
 

--- a/scripts/make_appimage.sh
+++ b/scripts/make_appimage.sh
@@ -118,3 +118,7 @@ chmod +x linuxdeploy-x86_64.AppImage
 log info "Creating the AppImage..."
 ./linuxdeploy-x86_64.AppImage --appimage-extract-and-run --appdir $APPDIR --output appimage
 mv vesyla-x86_64.AppImage ../vesyla
+
+# Show success message
+echo "AppImage created successfully!"
+../vesyla --version


### PR DESCRIPTION
# fix: removed cmake version parsing of Cargo.toml

## Description

* Removed logic in `CMakeLists.txt` for reading and parsing the version number from `Cargo.toml`.
* Removed the version from vs-entry Cargo.toml as it is now managed at build using the git tag.
* Cleared a unused import warning in main.rs: b9d76ffb352bed6c2aa1a79e424e42caa3593dfb.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally
- Tested in the PR workflow

**Test Configuration**:

- OS: Ubuntu 22.04

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
