### PR TITLE
feat(build): update CMakeLists.txt to use clang if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ if(CLANG_PATH
   set(CMAKE_CXX_COMPILER
       "${CLANGXX_PATH}"
       CACHE STRING "C++ compiler" FORCE)
+  message(STATUS "Using clang as C compiler: ${CMAKE_C_COMPILER}")
+  message(STATUS "Using clang++ as C++ compiler: ${CMAKE_CXX_COMPILER}")
 endif()
 
 project(vesyla)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 
+# Try to find clang and clang++ in PATH
+find_program(CLANG_PATH clang)
+find_program(CLANGXX_PATH clang++)
+
+# If both are found and user hasn't set a compiler, use them
+if(CLANG_PATH
+   AND CLANGXX_PATH
+   AND NOT DEFINED ENV{CC}
+   AND NOT DEFINED ENV{CXX})
+  set(CMAKE_C_COMPILER
+      "${CLANG_PATH}"
+      CACHE STRING "C compiler" FORCE)
+  set(CMAKE_CXX_COMPILER
+      "${CLANGXX_PATH}"
+      CACHE STRING "C++ compiler" FORCE)
+endif()
+
 project(vesyla)
 
 # Find includes in corresponding build directories
@@ -20,19 +37,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 
 include(FetchContent)
 fetchcontent_declare(
-    Corrosion
-    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.5.2
-)
+  Corrosion
+  GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+  GIT_TAG v0.5.2)
 fetchcontent_makeavailable(Corrosion)
 
 get_filename_component(CORROSION_TARGET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 message(STATUS "Target name: ${CORROSION_TARGET_NAME}")
 
 corrosion_import_crate(
-    MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/modules/Cargo.toml"
-    PROFILE release
-)
+  MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/modules/Cargo.toml" PROFILE
+  release)
 
 add_subdirectory("modules/vs-testcase")
 add_subdirectory("modules/vs-schedule")
@@ -40,14 +55,21 @@ add_subdirectory("modules/vs-compile")
 
 install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/vesyla DESTINATION bin)
 install(
-    DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
-    DESTINATION bin
-    FILES_MATCHING PATTERN "vs-*"
+  DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+  DESTINATION bin
+  FILES_MATCHING
+  PATTERN
+    "vs-*"
     PERMISSIONS
-      OWNER_EXECUTE OWNER_READ OWNER_WRITE
-      GROUP_EXECUTE GROUP_READ GROUP_WRITE
-      WORLD_EXECUTE WORLD_READ WORLD_WRITE
-)
+      OWNER_EXECUTE
+      OWNER_READ
+      OWNER_WRITE
+      GROUP_EXECUTE
+      GROUP_READ
+      GROUP_WRITE
+      WORLD_EXECUTE
+      WORLD_READ
+      WORLD_WRITE)
 install(DIRECTORY assets/applications DESTINATION share)
 file(COPY assets/applications DESTINATION ${CMAKE_BINARY_DIR}/share)
 install(DIRECTORY assets/icons DESTINATION share)

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -8,7 +8,12 @@ set -x
 if [ -f /etc/lsb-release ]; then
   # Ubuntu
   sudo apt-get update
-  sudo apt-get install -y cmake curl python3 python3-pip python3-venv protobuf-compiler libprotobuf-dev wget libfuse2 file flex bison
+  sudo apt-get install -y \
+    clang cmake \
+    curl file wget \
+    python3 python3-pip python3-venv \
+    protobuf-compiler libprotobuf-dev \
+    libfuse2 flex bison
 elif [ -f /etc/debian_version ]; then
   # Debian
   sudo apt-get update


### PR DESCRIPTION
# feat(build): update CMakeLists.txt to use clang if available

## Description

* Added logic to detect `clang` and `clang++` in the system's PATH and set them as the default compilers if no other compilers are specified in the environment. [CMakeLists.txtR3-R19](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR3-R19)
* Added `clang` to Ubuntu install dependencies script [./scripts/install_dependencies.sh](./scripts/install_dependencies.sh)

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested the build locally
- Tested running drra-tests locally
- Tested with the PR workflow 

**Test Configuration**:

- OS: Ubuntu 24.04
- [drra-components](https://github.com/silagokth/drra-components): v2.6.1-17-g18d7b7b

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules