### PR TITLE
feat(vs-component): updated the sst template to use differentiate io_links for input and output buffers

### DIFF
--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -93,6 +93,7 @@ jobs:
           source .venv/bin/activate
           pip install -r requirements.txt
           export VESYLA_SUITE_PATH_COMPONENTS=$(readlink -e ../library)
+          vesyla --version
           vesyla testcase generate -d ./testcases
           ./run.sh
 

--- a/modules/vs-component/src/utils.rs
+++ b/modules/vs-component/src/utils.rs
@@ -467,25 +467,51 @@ pub fn copy_rtl_dir(src: &Path, dst: &Path) -> Result<()> {
                 .is_some_and(|ext| ext == "sv" || ext == "v")
             {
                 let comment = "// ".to_string() + comment_content;
-                let content = fs::read_to_string(&path).expect("Failed to read file");
+                let content = fs::read_to_string(&path)
+                    .unwrap_or_else(|e| panic!("Failed to read file {}: {}", path.display(), e));
                 let new_content = comment + &content;
-                fs::write(&target_path, new_content).expect("Failed to write file");
+                fs::write(&target_path, new_content).unwrap_or_else(|e| {
+                    panic!("Failed to write file {}: {}", target_path.display(), e)
+                });
             } else if path
                 .extension()
                 .is_some_and(|ext| ext == "vhdl" || ext == "vhd")
             {
                 let comment = "-- ".to_string() + comment_content;
-                let content = fs::read_to_string(&path).expect("Failed to read file");
+                let content = fs::read_to_string(&path)
+                    .unwrap_or_else(|e| panic!("Failed to read file {}: {}", path.display(), e));
                 let new_content = comment + &content;
-                fs::write(&target_path, new_content).expect("Failed to write file");
+                fs::write(&target_path, new_content).unwrap_or_else(|e| {
+                    panic!("Failed to write file {}: {}", target_path.display(), e)
+                });
             } else {
                 // Just copy other files
-                fs::copy(&path, &target_path).expect("Failed to copy file");
+                fs::copy(&path, &target_path).unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to copy file {} to {}: {}",
+                        path.display(),
+                        target_path.display(),
+                        e
+                    )
+                });
             }
         } else if path.is_dir() {
             // For subdirectories, use the existing copy_dir function
-            fs::create_dir_all(&target_path).expect("Failed to create directory");
-            copy_dir(&path, &target_path).expect("Failed to copy directory");
+            fs::create_dir_all(&target_path).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to create dir for file {}: {}",
+                    target_path.display(),
+                    e
+                )
+            });
+            copy_dir(&path, &target_path).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to copy file {} to {}: {}",
+                    path.display(),
+                    target_path.display(),
+                    e
+                )
+            });
         }
     }
 

--- a/modules/vs-component/sst/sst_sim_template.py.jinja
+++ b/modules/vs-component/sst/sst_sim_template.py.jinja
@@ -136,13 +136,13 @@ print(f"[SST SIM] - Initializing resource {resource_name}")
 {%- if resource.io_input is defined and resource.io_input == True %}
 {{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}_to_input_buffer = sst.Link("link_{{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}_to_input_buffer")
 {{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}_to_input_buffer.connect(
-    ({{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}, "io_port", default_access_time), (input_buffer, "col_port{{c}}", default_access_time)
+    ({{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}, "io_input_port", default_access_time), (input_buffer, "col_port{{c}}", default_access_time)
 )
 {%- endif %}
 {%- if resource.io_output is defined and resource.io_output == True %}
 {{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}_to_output_buffer = sst.Link("link_{{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}_to_output_buffer")
 {{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}_to_output_buffer.connect(
-    ({{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}, "io_port", default_access_time), (output_buffer, "col_port{{c}}", default_access_time)
+    ({{resource.kind}}_{{r}}_{{c}}_{{resource.slot}}, "io_output_port", default_access_time), (output_buffer, "col_port{{c}}", default_access_time)
 )
 {%- endif %}
 


### PR DESCRIPTION
# feat(vs-component): updated the sst template to use differentiate io_links for input and output buffers

## Description

Currently, in SST DRRA components, the IO connections are done through the `io_port` and using a single `io_link`.
While this works for components that are connected to a single IO buffer (i.e., IOSRAM BTM & TOP), this will not work if the component has to connect to two IO buffers (i.e., IOSRAM BOTH).
_This issue was not detected before because we do not cover IOSRAM BOTH with our drra-tests. We have to fix this, see issue https://github.com/silagokth/drra-tests/issues/8_.

This PR fixes this issue by using differentiated `io_input_port` and `io_output_port`, and corresponding links.

This PR depends on https://github.com/silagokth/drra-components/pull/97.

This PR **does not** need an update to [silagokth/drra-tests](https://github.com/silagokth/drra-tests) to be merged.

Documentation: The documentation will be updated when merging the sst-guide branch of silagodoc to master, see https://github.com/silagokth/SiLagoDoc/blob/dc04b9ae19cf8dfb2f5daf619323ef8295f6e845/docs/ToolChain/Vesyla/Reference/SST/DRRA_SST_base.md?plain=1#L49-L54.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally by running the drra-tests with the updated drra-components (https://github.com/silagokth/drra-components/pull/97).
- The automatic test of this PR can only PASS if https://github.com/silagokth/drra-components/pull/97 is merged first.

**Test Configuration**:

- OS: Ubuntu 24.04
- [drra-components](https://github.com/silagokth/drra-components): https://github.com/silagokth/drra-components/pull/97
- Other experimental setup details: no changes to drra-tests

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules