### PR TITLE
feat(vs-compile): activation modes and scheduling refactor

### DIFF
--- a/modules/vs-compile/src/pasm/AddDefaultValuePass.cpp
+++ b/modules/vs-compile/src/pasm/AddDefaultValuePass.cpp
@@ -30,7 +30,7 @@ public:
     if (!parent_op) {
       llvm::outs()
           << "Error: InstrOp must be inside a RopOp or CopOp or RawOp.\n";
-      exit(-1);
+      exit(EXIT_FAILURE);
     }
     std::string label = "";
     if (auto rop_op = llvm::dyn_cast<RopOp>(parent_op)) {
@@ -51,13 +51,13 @@ public:
     } else {
       llvm::outs()
           << "Error: InstrOp must be inside a RopOp or CopOp or RawOp.\n";
-      exit(-1);
+      exit(EXIT_FAILURE);
     }
 
     if (component_map_json.find(label) == component_map_json.end()) {
       llvm::outs() << "Error: Cannot find the component for label: " << label
                    << "\n";
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
     std::string resource_kind = component_map_json[label].get<std::string>();
     // save the dictionary attributes of the InstrOp to a small vector

--- a/modules/vs-compile/src/pasm/AddSlotPortPass.cpp
+++ b/modules/vs-compile/src/pasm/AddSlotPortPass.cpp
@@ -46,7 +46,7 @@ public:
                 llvm::outs()
                     << "Warning: Slot mismatch in InstrOp: " << instr_slot
                     << " != " << slot << "\n";
-                exit(-1);
+                exit(EXIT_FAILURE);
               } else {
                 // Keep the original attribute if it matches the slot
                 updated_attrs.push_back(named_attr_entry);
@@ -58,7 +58,7 @@ public:
                 llvm::outs()
                     << "Warning: Port mismatch in InstrOp: " << instr_port
                     << " != " << port << "\n";
-                exit(-1);
+                exit(EXIT_FAILURE);
               } else {
                 // Keep the original attribute if it matches the port
                 updated_attrs.push_back(named_attr_entry);

--- a/modules/vs-compile/src/pasm/Config.cpp
+++ b/modules/vs-compile/src/pasm/Config.cpp
@@ -13,7 +13,7 @@ void Config::set_isa_json(std::string isa_json_path) {
   std::ifstream ifs(isa_json_path);
   if (!ifs.is_open()) {
     LOG_FATAL << "Error: Failed to open ISA JSON file: " << isa_json_path;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   isa_json = nlohmann::json::parse(ifs);
   ifs.close();
@@ -23,7 +23,7 @@ void Config::set_arch_json(std::string arch_json_path) {
   if (!ifs.is_open()) {
     LOG_FATAL << "Error: Failed to open Architecture JSON file: "
               << arch_json_path;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   arch_json = nlohmann::json::parse(ifs);
   ifs.close();

--- a/modules/vs-compile/src/pasm/MergeRawOp.cpp
+++ b/modules/vs-compile/src/pasm/MergeRawOp.cpp
@@ -23,7 +23,7 @@ public:
     mlir::Block *moduleBlock = op.getOperation()->getBlock();
     if (!moduleBlock) {
       llvm::outs() << "Error: EpochOp is not inside a block.\n";
-      exit(-1);
+      exit(EXIT_FAILURE);
     }
 
     // Iterate through all operations in the module's block
@@ -43,7 +43,7 @@ public:
         mlir::Region &child_op_region = epoch_op.getBody();
         if (child_op_region.empty()) {
           llvm::outs() << "Error: EpochOp has no body.\n";
-          exit(-1);
+          exit(EXIT_FAILURE);
         }
         mlir::Block *child_op_block = &child_op_region.front();
         // Iterate through all operations in the child operation's block
@@ -54,7 +54,7 @@ public:
           } else {
             llvm::outs() << "Error: Illegal operation type in EpochOp: "
                          << child_op_child.getName() << "\n";
-            exit(-1);
+            exit(EXIT_FAILURE);
           }
         }
       } else {
@@ -90,7 +90,7 @@ public:
         } else {
           llvm::outs() << "Error: RawOp already exists in the target epoch op: "
                        << label << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
       }
     }
@@ -143,7 +143,7 @@ public:
                 } else {
                   llvm::outs() << "Error: Illegal operation type in RawOp: "
                                << raw_op_child.getName() << "\n";
-                  exit(-1);
+                  exit(EXIT_FAILURE);
                 }
               }
             } else {
@@ -179,7 +179,7 @@ public:
         mlir::Region &epochBodyRegion = epoch_op.getBody();
         if (epochBodyRegion.empty()) {
           llvm::outs() << "Error: EpochOp has no body.\n";
-          exit(-1);
+          exit(EXIT_FAILURE);
         }
         mlir::Block *epochEntryBlock = &epochBodyRegion.front();
         // Iterate through all operations in the child operation's block
@@ -192,7 +192,7 @@ public:
           } else {
             llvm::outs() << "Error: Illegal operation type in EpochOp: "
                          << epoch_child_op.getName() << "\n";
-            exit(-1);
+            exit(EXIT_FAILURE);
           }
         }
       }

--- a/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
+++ b/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
@@ -1136,8 +1136,13 @@ public:
                                std::istreambuf_iterator<char>());
         output_file.close();
 
-        model.add_operation(
-            tm::Operation(rop_json["id"].get<std::string>(), output_str));
+        tm::Operation operation =
+            tm::Operation(rop_json["id"].get<std::string>(), output_str);
+        operation.col = rop_json["col"].get<int>();
+        operation.row = rop_json["row"].get<int>();
+        operation.slot = rop_json["slot"].get<int>();
+        operation.port = rop_json["port"].get<int>();
+        model.add_operation(operation);
 
         // delete the temporary files
         remove(input_filename.c_str());

--- a/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
+++ b/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
@@ -1297,6 +1297,9 @@ public:
         continue;
       }
 
+      // TODO(paul) if both modes are false
+      // generate the activation vectors for each activation cycle
+
       // if value is not starting with "[", then it is a number
       if (value[0] != '[') {
         schedule_table[key] = std::stoi(value);

--- a/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
+++ b/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
@@ -116,7 +116,7 @@ private:
 
     if (indices.size() == 0) {
       llvm::outs() << "Error: No port indices provided.\n";
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
 
     // try ACT mode 0
@@ -143,7 +143,7 @@ private:
         llvm::outs() << index << " ";
       }
       llvm::outs() << "\n";
-      exit(-1); // invalid combination of port indices for mode 1
+      exit(EXIT_FAILURE); // invalid combination of port indices for mode 1
     }
   }
 
@@ -187,7 +187,7 @@ private:
                 llvm::outs()
                     << "Unsupported parameter type in InstrOp: " << param_value
                     << "\n";
-                std::exit(-1);
+                std::exit(EXIT_FAILURE);
               }
             }
 
@@ -207,7 +207,7 @@ private:
           } else {
             llvm::outs() << "Illegal operation type in RopOp: "
                          << rop_child_op.getName() << "\n";
-            std::exit(-1);
+            std::exit(EXIT_FAILURE);
           }
         }
       }
@@ -243,7 +243,7 @@ private:
                 llvm::outs()
                     << "Unsupported parameter type in InstrOp: " << param_value
                     << "\n";
-                std::exit(-1);
+                std::exit(EXIT_FAILURE);
               }
             }
 
@@ -262,14 +262,14 @@ private:
           } else {
             llvm::outs() << "Illegal operation type in CopOp: "
                          << cop_child_op.getName() << "\n";
-            std::exit(-1);
+            std::exit(EXIT_FAILURE);
           }
         }
       }
     } else {
       llvm::outs() << "Unsupported operation type for JSON conversion: "
                    << op->getName() << "\n";
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
 
     return op_json;
@@ -378,7 +378,7 @@ private:
     } else {
       llvm::outs() << "Unsupported operation kind: "
                    << op_json["kind"].get<std::string>() << "\n";
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
   }
 
@@ -505,7 +505,7 @@ private:
     auto epoch_op = *op;
     if (!epoch_op) {
       llvm::outs() << "Error: Cannot find the EpochOp in the operation.\n";
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
     mlir::Region &epochBodyRegion = epoch_op.getBody();
     mlir::Block *block;
@@ -544,7 +544,7 @@ private:
         if (component_map.find(label) == component_map.end()) {
           llvm::outs() << "Error: Cannot find the component : " << label
                        << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         std::string command = component_path + "/resources/" +
                               component_map[label].get<std::string>() +
@@ -556,7 +556,7 @@ private:
         std::ofstream file(input_filename);
         if (!file.is_open()) {
           llvm::outs() << "Error: Failed to create temporary file.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         file << rop_json.dump(4);
         file.close();
@@ -564,14 +564,14 @@ private:
         if (result != 0) {
           llvm::outs() << "Error: Command failed with error code: " << result
                        << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
 
         // read the output file
         std::ifstream output_file(output_filename);
         if (!output_file.is_open()) {
           llvm::outs() << "Error: Failed to open output file.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         nlohmann::json output_json = nlohmann::json::parse(output_file);
         output_file.close();
@@ -580,7 +580,7 @@ private:
         std::filesystem::remove(output_filename);
         if (output_json["kind"].get<std::string>() != "rop") {
           llvm::outs() << "Error: Output JSON is not a RopOp.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         // convert the output JSON to operation
         rewriter.setInsertionPointToEnd(block);
@@ -606,7 +606,7 @@ private:
         if (component_map.find(label) == component_map.end()) {
           llvm::outs() << "Error: Cannot find the component : " << label
                        << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         std::string command = component_path + "/resources/" +
                               component_map[label].get<std::string>() +
@@ -618,7 +618,7 @@ private:
         std::ofstream file(input_filename);
         if (!file.is_open()) {
           llvm::outs() << "Error: Failed to create temporary file.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         file << cop_json.dump(4);
         file.close();
@@ -626,14 +626,14 @@ private:
         if (result != 0) {
           llvm::outs() << "Error: Command failed with error code: " << result
                        << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
 
         // read the output file
         std::ifstream output_file(output_filename);
         if (!output_file.is_open()) {
           llvm::outs() << "Error: Failed to open output file.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         nlohmann::json output_json = nlohmann::json::parse(output_file);
         output_file.close();
@@ -642,7 +642,7 @@ private:
         std::filesystem::remove(output_filename);
         if (output_json["kind"].get<std::string>() != "cop") {
           llvm::outs() << "Error: Output JSON is not a CopOp.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         // convert the output JSON to operation
         rewriter.setInsertionPointToEnd(block);
@@ -658,7 +658,7 @@ private:
       } else {
         llvm::outs() << "Illegal operation type in EpochOp: "
                      << child_op->getName() << "\n";
-        std::exit(-1);
+        std::exit(EXIT_FAILURE);
       }
     }
 
@@ -676,7 +676,7 @@ private:
     auto epoch_op = *op;
     if (!epoch_op) {
       llvm::outs() << "Error: Cannot find the EpochOp in the operation.\n";
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
     mlir::Region &epochBodyRegion = epoch_op.getBody();
     mlir::Block *block;
@@ -722,7 +722,7 @@ private:
         llvm::outs()
             << "Illegal operation type in EpochOp for synchronization: "
             << child_op.getName() << "\n";
-        std::exit(-1);
+        std::exit(EXIT_FAILURE);
       }
     }
 
@@ -754,7 +754,7 @@ private:
                          << instr_op.getId().str() + "_e" +
                                 std::to_string(instr_count)
                          << "\n";
-            std::exit(-1);
+            std::exit(EXIT_FAILURE);
           }
           int t = schedule_table[instr_op.getId().str() + "_e" +
                                  std::to_string(instr_count)];
@@ -764,7 +764,7 @@ private:
             llvm::outs() << "Error: time table already has the entry: " << t
                          << "(" << time_table[label][t]->getName() << ")"
                          << "\n";
-            std::exit(-1);
+            std::exit(EXIT_FAILURE);
           }
           instr_count++;
         } else if (auto yield_op = llvm::dyn_cast<YieldOp>(&cop_child_op)) {
@@ -772,7 +772,7 @@ private:
         } else {
           llvm::outs() << "Illegal operation type in CopOp: "
                        << cop_child_op.getName() << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
       }
     }
@@ -834,7 +834,7 @@ private:
           llvm::outs() << "Error: time table already has the entry: " << t
                        << "(" << time_table[label][t]->getName() << ")"
                        << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
 
         llvm::outs() << "ACT: " << act_instr.getId() << " at time " << t
@@ -1165,7 +1165,7 @@ public:
         if (component_map.find(label) == component_map.end()) {
           llvm::outs() << "Error: Cannot find the component : " << label
                        << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         std::string command = component_path + "/resources/" +
                               component_map[label].get<std::string>() +
@@ -1177,7 +1177,7 @@ public:
         std::ofstream file(input_filename);
         if (!file.is_open()) {
           llvm::outs() << "Error: Failed to create temporary file.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         file << rop_json.dump(4);
         file.close();
@@ -1185,14 +1185,14 @@ public:
         if (result != 0) {
           llvm::outs() << "Error: Command failed with error code: " << result
                        << "\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
 
         // read the output file
         std::ifstream output_file(output_filename);
         if (!output_file.is_open()) {
           llvm::outs() << "Error: Failed to open output file.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         std::string output_str((std::istreambuf_iterator<char>(output_file)),
                                std::istreambuf_iterator<char>());
@@ -1222,7 +1222,7 @@ public:
         if ((operation_type_set.find("pasm.rop") != operation_type_set.end()) ||
             operation_type_set.find("pasm.cop") != operation_type_set.end()) {
           llvm::outs() << "Error: RawOp cannot be used with RopOp or CopOp.\n";
-          std::exit(-1);
+          std::exit(EXIT_FAILURE);
         }
         return failure();
       } else if (auto cstr_op = llvm::dyn_cast<CstrOp>(&child_op)) {
@@ -1234,7 +1234,7 @@ public:
       } else {
         llvm::outs() << "Illegal operation type in EpochOp: "
                      << child_op.getName() << "\n";
-        std::exit(-1);
+        std::exit(EXIT_FAILURE);
       }
       operation_type_set.insert(child_op.getName().getStringRef().str());
     }
@@ -1272,7 +1272,7 @@ public:
       } else {
         llvm::outs() << "Error: Illegal operation kind in EpochOp: "
                      << op_expr.kind << "\n";
-        std::exit(-1);
+        std::exit(EXIT_FAILURE);
       }
     }
 
@@ -1315,7 +1315,7 @@ public:
     std::unordered_map<std::string, std::string> result = solver.solve(model);
     if (result.empty()) {
       llvm::outs() << "Error: No solution found.\n";
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
 
     std::unordered_map<std::string, int> schedule_table;

--- a/modules/vs-compile/src/schedule/Generator.cpp
+++ b/modules/vs-compile/src/schedule/Generator.cpp
@@ -29,7 +29,7 @@ void Generator::gen_asm(mlir::ModuleOp module, const std::string &output_dir,
   std::ofstream output_file(output_dir + "/" + filename);
   if (!output_file.is_open()) {
     LOG_FATAL << "Error: Failed to open output file.";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 
   mlir::Region &module_region = module.getBodyRegion();
@@ -79,7 +79,7 @@ void Generator::gen_asm(mlir::ModuleOp module, const std::string &output_dir,
                         llvm::outs()
                             << "Unsupported parameter type in InstrOp: "
                             << attr_value << "\n";
-                        std::exit(-1);
+                        std::exit(EXIT_FAILURE);
                       }
                     }
 
@@ -91,7 +91,7 @@ void Generator::gen_asm(mlir::ModuleOp module, const std::string &output_dir,
                   } else {
                     llvm::outs() << "Error: Illegal operation type in RawOp: "
                                  << child_child_child_op.getName() << "\n";
-                    std::exit(-1);
+                    std::exit(EXIT_FAILURE);
                   }
                 }
               }
@@ -101,7 +101,7 @@ void Generator::gen_asm(mlir::ModuleOp module, const std::string &output_dir,
             } else {
               llvm::outs() << "Error: Illegal operation type in EpochOp: "
                            << child_op.getName() << "\n";
-              std::exit(-1);
+              std::exit(EXIT_FAILURE);
             }
           }
         }
@@ -111,7 +111,7 @@ void Generator::gen_asm(mlir::ModuleOp module, const std::string &output_dir,
       } else {
         llvm::outs() << "Error: Illegal operation type in ModuleOp: "
                      << child_op.getName() << "\n";
-        std::exit(-1);
+        std::exit(EXIT_FAILURE);
       }
     }
   }
@@ -137,7 +137,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
   std::ofstream output_file(output_dir + "/" + filename);
   if (!output_file.is_open()) {
     llvm::outs() << "Error: Failed to open output file.\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 
   mlir::Region &module_region = module.getBodyRegion();
@@ -182,7 +182,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
                           llvm::outs()
                               << "Unsupported parameter type in InstrOp: "
                               << attr_value << "\n";
-                          std::exit(-1);
+                          std::exit(EXIT_FAILURE);
                         }
                       } else if (attr_name.str() == "port") {
                         if (auto int_attr =
@@ -192,7 +192,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
                           llvm::outs()
                               << "Unsupported parameter type in InstrOp: "
                               << attr_value << "\n";
-                          std::exit(-1);
+                          std::exit(EXIT_FAILURE);
                         }
                       }
                     }
@@ -208,7 +208,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
                       llvm::outs() << "Error: Cannot find the component for "
                                       "label: "
                                    << label << "\n";
-                      std::exit(-1);
+                      std::exit(EXIT_FAILURE);
                     }
                     std::string component_kind =
                         component_map_json[label].get<std::string>();
@@ -229,7 +229,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
                       llvm::outs() << "Error: Cannot find the instruction "
                                       "definition for: "
                                    << instr_type << "\n";
-                      std::exit(-1);
+                      std::exit(EXIT_FAILURE);
                     }
                     std::string instr_bin = "";
                     instr_bin += int2bin(instr_json["instr_type"].get<int>(),
@@ -255,14 +255,14 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
                           llvm::outs()
                               << "Unsupported parameter type in InstrOp: "
                               << attr_value << "\n";
-                          std::exit(-1);
+                          std::exit(EXIT_FAILURE);
                         }
                       } else {
                         llvm::outs()
                             << "Error: Missing parameter '" << segment_name
                             << "' in InstrOp for instruction: " << instr_type
                             << "\n";
-                        std::exit(-1);
+                        std::exit(EXIT_FAILURE);
                       }
                     }
 
@@ -275,7 +275,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
                                    << instr_bin.size()
                                    << " exceeds the required bitwidth: "
                                    << instr_bitwidth << "\n";
-                      std::exit(-1);
+                      std::exit(EXIT_FAILURE);
                     }
 
                     output_file << instr_bin << "\n";
@@ -286,7 +286,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
                   } else {
                     llvm::outs() << "Error: Illegal operation type in RawOp: "
                                  << child_child_child_op.getName() << "\n";
-                    std::exit(-1);
+                    std::exit(EXIT_FAILURE);
                   }
                 }
               }
@@ -297,7 +297,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
             } else {
               llvm::outs() << "Error: Illegal operation type in EpochOp: "
                            << child_op.getName() << "\n";
-              std::exit(-1);
+              std::exit(EXIT_FAILURE);
             }
           }
         }
@@ -307,7 +307,7 @@ void Generator::gen_bin(mlir::ModuleOp module, const std::string &output_dir,
       } else {
         llvm::outs() << "Error: Illegal operation type in ModuleOp: "
                      << child_op.getName() << "\n";
-        std::exit(-1);
+        std::exit(EXIT_FAILURE);
       }
     }
   }

--- a/modules/vs-compile/src/schedule/Parser.cpp
+++ b/modules/vs-compile/src/schedule/Parser.cpp
@@ -18,7 +18,7 @@ void Parser::parse(std::string &filename_, mlir::ModuleOp *module_) {
   // Make sure the file is valid
   if (!inputfile) {
     LOG_FATAL << "Error: Failed to open input file: " << filename_;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 
   strncpy(global_input_file_name, filename_.c_str(), 80);

--- a/modules/vs-compile/src/schedule/Scheduler.cpp
+++ b/modules/vs-compile/src/schedule/Scheduler.cpp
@@ -8,7 +8,7 @@ void Scheduler::save_mlir(mlir::ModuleOp &module, const std::string &filename) {
   llvm::raw_fd_ostream ofs(filename, error_code);
   if (error_code) {
     LOG_FATAL << "Error: Failed to open file for writing: " << filename << "\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   module.print(ofs);
   ofs.close();
@@ -37,7 +37,7 @@ void Scheduler::run(mlir::ModuleOp &module, std::string output_dir) {
           : "";
   if (VESYLA_SUITE_PATH_COMPONENTS == "") {
     LOG_FATAL << "Error: VESYLA_SUITE_PATH_COMPONENTS is not set.\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 
   // create temp directory for scheduler
@@ -53,14 +53,14 @@ void Scheduler::run(mlir::ModuleOp &module, std::string output_dir) {
   pm.addPass(vesyla::pasm::createAddSlotPortPass());
   if (mlir::failed(pm.run(module))) {
     LOG_FATAL << "Error: Pass pipeline failed.\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   pm.clear();
   save_mlir(module, module_debug_path + "/1.mlir");
   pm.addPass(vesyla::pasm::createAddDefaultValuePass());
   if (mlir::failed(pm.run(module))) {
     LOG_FATAL << "Error: Pass pipeline failed.\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   pm.clear();
   save_mlir(module, module_debug_path + "/2.mlir");
@@ -70,7 +70,7 @@ void Scheduler::run(mlir::ModuleOp &module, std::string output_dir) {
       {VESYLA_SUITE_PATH_COMPONENTS, temp_dir}));
   if (mlir::failed(pm.run(module))) {
     LOG_FATAL << "Error: Pass pipeline failed.\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   pm.clear();
   save_mlir(module, module_debug_path + "/3.mlir");
@@ -78,7 +78,7 @@ void Scheduler::run(mlir::ModuleOp &module, std::string output_dir) {
   pm.addPass(vesyla::pasm::createReplaceLoopOp());
   if (mlir::failed(pm.run(module))) {
     LOG_FATAL << "Error: Pass pipeline failed.\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   pm.clear();
   save_mlir(module, module_debug_path + "/4.mlir");
@@ -86,7 +86,7 @@ void Scheduler::run(mlir::ModuleOp &module, std::string output_dir) {
   pm.addPass(vesyla::pasm::createMergeRawOp());
   if (mlir::failed(pm.run(module))) {
     LOG_FATAL << "Error: Pass pipeline failed.\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   pm.clear();
   save_mlir(module, module_debug_path + "/5.mlir");
@@ -94,7 +94,7 @@ void Scheduler::run(mlir::ModuleOp &module, std::string output_dir) {
   pm.addPass(vesyla::pasm::createAddHaltPass());
   if (mlir::failed(pm.run(module))) {
     LOG_FATAL << "Error: Pass pipeline failed.\n";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   pm.clear();
   save_mlir(module, module_debug_path + "/6.mlir");

--- a/modules/vs-compile/src/tm/Anchor.cpp
+++ b/modules/vs-compile/src/tm/Anchor.cpp
@@ -15,7 +15,7 @@ AnchorExpr::AnchorExpr(string str) {
   // check if the str is empty
   if (str.empty()) {
     LOG_FATAL << "Anchor string is empty!" << str;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 
   // use regex to match <op_name>.<event_id>[<index_0>][<index_1>]...
@@ -37,7 +37,7 @@ AnchorExpr::AnchorExpr(string str) {
     }
   } else {
     LOG_FATAL << "Invalid anchor string: " << str;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 }
 

--- a/modules/vs-compile/src/tm/Constraint.cpp
+++ b/modules/vs-compile/src/tm/Constraint.cpp
@@ -22,7 +22,7 @@ Constraint::Constraint(string expr_str) {
     expr = match[2];
   } else {
     LOG_FATAL << "Invalid constraint string: " << expr_str;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 }
 string Constraint::to_string() { return "constraint " + kind + " " + expr; }

--- a/modules/vs-compile/src/tm/Operation.cpp
+++ b/modules/vs-compile/src/tm/Operation.cpp
@@ -24,7 +24,7 @@ Operation::Operation(string expr_str) {
     expr = OperationExpr(match[2]);
   } else {
     LOG_FATAL << "Invalid operation string: " << expr_str;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 }
 
@@ -40,7 +40,7 @@ OperationExpr::OperationExpr(string str) {
   // check if the str is empty
   if (str.empty()) {
     LOG_FATAL << "Operator string is empty!" << str;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 
   // distinguish the operator type by looking at the first character
@@ -52,7 +52,7 @@ OperationExpr::OperationExpr(string str) {
     kind = TRANSIT;
   } else {
     LOG_FATAL << "Invalid operator string: " << str;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
 
   if (kind == EVENT) {
@@ -65,7 +65,7 @@ OperationExpr::OperationExpr(string str) {
       parameters["id"] = match[1];
     } else {
       LOG_FATAL << "Invalid event string: " << str;
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
   } else if (kind == REPEAT) {
     // use regex to match R<iter, delay>(expr)
@@ -79,7 +79,7 @@ OperationExpr::OperationExpr(string str) {
       children.push_back(OperationExpr(match[3]));
     } else {
       LOG_FATAL << "Invalid repeat operator string: " << str;
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
   } else if (kind == TRANSIT) {
     // use regex to match T<delay>(expr_0, expr_1)
@@ -121,15 +121,15 @@ OperationExpr::OperationExpr(string str) {
       }
       if (bracket_curly != 0 || bracket_square != 0 || bracket_round != 0) {
         LOG_FATAL << "Invalid transit operator string: " << str;
-        std::exit(-1);
+        std::exit(EXIT_FAILURE);
       }
       if (children.size() != 2) {
         LOG_FATAL << "Invalid transit operator string: " << str;
-        std::exit(-1);
+        std::exit(EXIT_FAILURE);
       }
     } else {
       LOG_FATAL << "Invalid transit operator string: " << str;
-      std::exit(-1);
+      std::exit(EXIT_FAILURE);
     }
   }
 }

--- a/modules/vs-compile/src/tm/Operation.hpp
+++ b/modules/vs-compile/src/tm/Operation.hpp
@@ -28,6 +28,11 @@ struct Operation {
   OperationExpr expr;
   string duration_expr;
 
+  int col = -1;
+  int row = -1;
+  int slot = -1;
+  int port = -1;
+
   Operation() {}
   Operation(string name_, string expr_) : name(name_), expr(expr_) {}
   Operation(string name_, OperationExpr expr_) : name(name_), expr(expr_) {}

--- a/modules/vs-compile/src/tm/Solver.cpp
+++ b/modules/vs-compile/src/tm/Solver.cpp
@@ -107,21 +107,21 @@ void write_minizinc_files(TimingModel &tm, string mzn_filename,
   std::ofstream mzn_file(mzn_filename);
   if (!mzn_file.is_open()) {
     LOG_FATAL << "Failed to create MiniZinc model file: " << mzn_filename;
-    exit(-1);
+    exit(EXIT_FAILURE);
   }
 
   // Create the MiniZinc data file
   std::ofstream dzn_file(dzn_filename);
   if (!dzn_file.is_open()) {
     LOG_FATAL << "Failed to create MiniZinc data file: " << dzn_filename;
-    exit(-1);
+    exit(EXIT_FAILURE);
   }
 
   // Create the JSON output file
   std::ofstream json_file(json_filename);
   if (!json_file.is_open()) {
     LOG_FATAL << "Failed to create JSON output file: " << json_filename;
-    exit(-1);
+    exit(EXIT_FAILURE);
   }
 
   // Write the MiniZinc model content
@@ -146,11 +146,11 @@ void run_minizinc(string mzn_filename, string dzn_filename,
   LOG_DEBUG << "Minizinc command output file: " << json_filename;
   if (result == -1) {
     LOG_ERROR << "Failed to execute Minizinc command.";
-    exit(-1);
+    exit(EXIT_FAILURE);
   } else if (!WIFEXITED(result) || WEXITSTATUS(result) != 0) {
     LOG_ERROR << "Minizinc command failed with error code: "
               << WEXITSTATUS(result);
-    exit(-1);
+    exit(EXIT_FAILURE);
   }
 }
 
@@ -159,7 +159,7 @@ nlohmann::json get_json_from_file(const string &filename) {
   std::ifstream json_file(filename);
   if (!json_file.is_open()) {
     LOG_FATAL << "Failed to open JSON file: " << filename;
-    exit(-1);
+    exit(EXIT_FAILURE);
   }
   nlohmann::json json_output;
   json_file >> json_output;
@@ -198,7 +198,7 @@ unordered_map<string, string> Solver::solve(TimingModel &tm,
       LOG_ERROR << "Input DZN file: " << dzn_filename;
       LOG_ERROR << "Output: " << json_output.dump(4);
       LOG_FATAL << "Minizinc command failed.";
-      exit(-1);
+      exit(EXIT_FAILURE);
     }
   }
 

--- a/modules/vs-compile/src/tm/Solver.cpp
+++ b/modules/vs-compile/src/tm/Solver.cpp
@@ -16,30 +16,125 @@ string get_random_string(size_t length) {
   return result;
 }
 
-unordered_map<string, string> Solver::solve(TimingModel &tm) {
-  // create two temporary files with random names
-  string random_id = get_random_string(10);
-  string mzn_filename = tmp_path + "/" + random_id + ".mzn";
-  string dzn_filename = tmp_path + "/" + random_id + ".dzn";
-  string json_filename = tmp_path + "/" + random_id + ".json";
+void turn_to_valid_json(string json_input_filename,
+                        string json_output_filename) {
+  // Get the input file stream
+  std::ifstream input(json_input_filename);
+  std::ofstream output(json_output_filename);
 
+  // Read entire input into string
+  std::stringstream buffer;
+  buffer << input.rdbuf();
+  std::string invalidJson = buffer.str();
+
+  // Remove leading and trailing whitespace
+  size_t start = invalidJson.find_first_not_of(" \t\n\r");
+  size_t end = invalidJson.find_last_not_of(" \t\n\r");
+
+  if (start == std::string::npos) {
+    output << "[]";
+    return;
+  }
+
+  std::string trimmed = invalidJson.substr(start, end - start + 1);
+
+  // Simple approach: wrap in brackets and add commas between }{ patterns
+  std::string result = "[" + trimmed + "]";
+
+  // Find and replace "}  {" patterns with "}, {"
+  size_t pos = 0;
+  while ((pos = result.find("}", pos)) != std::string::npos) {
+    size_t nextBrace = result.find("{", pos + 1);
+    if (nextBrace != std::string::npos) {
+      // Check if there's only whitespace between } and {
+      bool onlyWhitespace = true;
+      for (size_t i = pos + 1; i < nextBrace; ++i) {
+        if (!std::isspace(result[i])) {
+          onlyWhitespace = false;
+          break;
+        }
+      }
+
+      if (onlyWhitespace) {
+        result.replace(pos, nextBrace - pos, "}, ");
+        pos += 3; // Move past the ", "
+      } else {
+        pos++;
+      }
+    } else {
+      break;
+    }
+  }
+
+  output << result;
+
+  input.close();
+  output.close();
+}
+
+bool check_mzn_solution_valid(nlohmann::json &json_output, string &solution) {
+  bool result = false;
+  // Find all the "type" entries in the JSON output
+  for (const auto &entry : json_output.items()) {
+    for (auto sub_entry : entry.value().items()) {
+      if (sub_entry.key() == "type") {
+        if (sub_entry.value() == "solution") {
+          result = true; // Found a solution
+        }
+      } else if (sub_entry.key() == "status") {
+        if (sub_entry.value() == "UNSATISFIABLE") {
+          solution = "UNSATISFIABLE";
+          result = false;
+          break; // No solution found
+        }
+      } else if (sub_entry.key() == "warning") {
+        LOG_WARNING << sub_entry.value();
+      } else if (sub_entry.key() == "output") {
+        auto sub_sub_entry = sub_entry.value().find("dzn");
+        solution = sub_sub_entry != sub_entry.value().end()
+                       ? sub_sub_entry->get<string>()
+                       : "no solution found";
+      }
+    }
+  }
+  return result; // No solution found
+}
+
+void write_minizinc_files(TimingModel &tm, string mzn_filename,
+                          string dzn_filename, string json_filename,
+                          bool allow_act_mode_2 = false) {
+  // Create the MiniZinc model file
   std::ofstream mzn_file(mzn_filename);
+  if (!mzn_file.is_open()) {
+    LOG_FATAL << "Failed to create MiniZinc model file: " << mzn_filename;
+    exit(-1);
+  }
+
+  // Create the MiniZinc data file
   std::ofstream dzn_file(dzn_filename);
-
-  if (!mzn_file.is_open() || !dzn_file.is_open()) {
-    LOG_FATAL << "Failed to create temporary files: " << mzn_filename << " and "
-              << dzn_filename << "\n";
+  if (!dzn_file.is_open()) {
+    LOG_FATAL << "Failed to create MiniZinc data file: " << dzn_filename;
     exit(-1);
   }
 
-  if (tm.to_mzn(mzn_file, dzn_file) != 0) {
-    LOG_FATAL << "Failed to convert TimingModel to MiniZinc.";
+  // Create the JSON output file
+  std::ofstream json_file(json_filename);
+  if (!json_file.is_open()) {
+    LOG_FATAL << "Failed to create JSON output file: " << json_filename;
     exit(-1);
   }
 
+  // Write the MiniZinc model content
+  tm.to_mzn(mzn_file, dzn_file, allow_act_mode_2);
+
+  // Close all files
   mzn_file.close();
   dzn_file.close();
+  json_file.close();
+}
 
+void run_minizinc(string mzn_filename, string dzn_filename,
+                  string json_filename) {
   // run minizinc command and collect the json output
   LOG_DEBUG << "Running Minizinc command with input files: " << mzn_filename
             << " and " << dzn_filename;
@@ -49,38 +144,68 @@ unordered_map<string, string> Solver::solve(TimingModel &tm) {
 
   LOG_DEBUG << "Minizinc command executed: " << command;
   LOG_DEBUG << "Minizinc command output file: " << json_filename;
-  if (result != 0) {
-    LOG_ERROR << "Minizinc command failed with error code: " << result;
-  }
-
-  // read the json output
-  ifstream json_file(json_filename);
-  if (!json_file.is_open()) {
-    LOG_FATAL << "Failed to open json file.";
+  if (result == -1) {
+    LOG_ERROR << "Failed to execute Minizinc command.";
+    exit(-1);
+  } else if (!WIFEXITED(result) || WEXITSTATUS(result) != 0) {
+    LOG_ERROR << "Minizinc command failed with error code: "
+              << WEXITSTATUS(result);
     exit(-1);
   }
+}
 
+nlohmann::json get_json_from_file(const string &filename) {
+  // Read the JSON file and return the parsed JSON object
+  std::ifstream json_file(filename);
+  if (!json_file.is_open()) {
+    LOG_FATAL << "Failed to open JSON file: " << filename;
+    exit(-1);
+  }
   nlohmann::json json_output;
   json_file >> json_output;
   json_file.close();
+  return json_output;
+}
 
-  // check if the output type is solution
-  if (json_output.find("type") == json_output.end() ||
-      json_output["type"] != "solution") {
-    LOG_ERROR << "Minizinc output is not a solution.";
-    LOG_ERROR << "Input MZN file: " << mzn_filename;
-    LOG_ERROR << "Input DZN file: " << dzn_filename;
-    LOG_ERROR << "Output: " << json_output.dump(4);
-    LOG_FATAL << "Minizinc command failed.";
-    exit(-1);
+unordered_map<string, string> Solver::solve(TimingModel &tm,
+                                            bool allow_act_mode_2) {
+  // create two temporary files with random names
+  string random_id = get_random_string(10);
+  string mzn_filename = tmp_path + random_id + ".mzn";
+  string dzn_filename = tmp_path + random_id + ".dzn";
+  string json_filename = tmp_path + random_id + ".json";
+  string edited_json_filename = tmp_path + random_id + "_fixed.json";
+
+  write_minizinc_files(tm, mzn_filename, dzn_filename, json_filename);
+  run_minizinc(mzn_filename, dzn_filename, json_filename);
+  turn_to_valid_json(json_filename, edited_json_filename);
+  nlohmann::json json_output = get_json_from_file(edited_json_filename);
+
+  string solution;
+  if (!check_mzn_solution_valid(json_output, solution)) {
+    solution.clear();
+    json_output.clear();
+
+    // rerun minizinc allowing act mode 2
+    write_minizinc_files(tm, mzn_filename, dzn_filename, json_filename, true);
+    run_minizinc(mzn_filename, dzn_filename, json_filename);
+    turn_to_valid_json(json_filename, edited_json_filename);
+    json_output = get_json_from_file(edited_json_filename);
+
+    if (!check_mzn_solution_valid(json_output, solution)) {
+      LOG_ERROR << "Minizinc command failed to find a solution.";
+      LOG_ERROR << "Input MZN file: " << mzn_filename;
+      LOG_ERROR << "Input DZN file: " << dzn_filename;
+      LOG_ERROR << "Output: " << json_output.dump(4);
+      LOG_FATAL << "Minizinc command failed.";
+      exit(-1);
+    }
   }
 
-  // delete the temporary files
-  // remove(input_filename.c_str());
-  // remove(output_filename.c_str());
+  LOG_DEBUG << "Minizinc command found a solution: " << solution;
 
   // get output
-  string output_str = json_output["output"]["dzn"].get<string>();
+  string output_str = solution;
 
   // divide the output by delimiter \n
   vector<string> output_lines;

--- a/modules/vs-compile/src/tm/Solver.hpp
+++ b/modules/vs-compile/src/tm/Solver.hpp
@@ -13,7 +13,8 @@ public:
   Solver() { tmp_path = "."; }
   Solver(std::string tmp_path_) : tmp_path(tmp_path_) {}
   ~Solver() {}
-  std::unordered_map<std::string, std::string> solve(TimingModel &tm);
+  std::unordered_map<std::string, std::string>
+  solve(TimingModel &tm, bool allow_act_mode_2 = false);
 };
 } // namespace tm
 } // namespace vesyla

--- a/modules/vs-compile/src/tm/TimingModel.cpp
+++ b/modules/vs-compile/src/tm/TimingModel.cpp
@@ -1,3 +1,5 @@
+// TODO this should come from a config file
+// or global variables at some point
 #define MAX_SLOTS 16
 #define NUM_PORTS_PER_RESOURCE 4
 

--- a/modules/vs-compile/src/tm/TimingModel.cpp
+++ b/modules/vs-compile/src/tm/TimingModel.cpp
@@ -36,7 +36,7 @@ int TimingModel::to_mzn(std::ostream &mzn_file, std::ostream &dzn_file,
   if (state != COMPILED) {
     LOG_WARNING << "Timing model is not compiled. Compiling...";
     compile();
-    LOG_WARNING << "Timing model compiled.";
+    LOG_DEBUG << "Timing model compiled.";
   }
 
   // build translation table for operations

--- a/modules/vs-compile/src/tm/TimingModel.cpp
+++ b/modules/vs-compile/src/tm/TimingModel.cpp
@@ -28,7 +28,8 @@ string TimingModel::to_string() {
   return str;
 }
 
-int TimingModel::to_mzn(std::ostream &mzn_file, std::ostream &dzn_file) {
+int TimingModel::to_mzn(std::ostream &mzn_file, std::ostream &dzn_file,
+                        bool allow_act_mode_2) {
   if (state != COMPILED) {
     LOG_WARNING << "Timing model is not compiled. Compiling...";
     compile();
@@ -136,7 +137,11 @@ int TimingModel::to_mzn(std::ostream &mzn_file, std::ostream &dzn_file) {
   // add act modes
   mzn_file << "var bool: use_act_mode_0;\n";
   mzn_file << "var bool: use_act_mode_1;\n";
-  mzn_file << "constraint (use_act_mode_0 + use_act_mode_1) = 1;\n";
+  if (allow_act_mode_2) {
+    mzn_file << "constraint (use_act_mode_0 + use_act_mode_1) <= 1;\n";
+  } else {
+    mzn_file << "constraint (use_act_mode_0 + use_act_mode_1) = 1;\n";
+  }
   mzn_file << R"(
 % act mode 0: if resources are within 4 slots of each other
 % then their start times can be the same, else they must not have the same start time

--- a/modules/vs-compile/src/tm/TimingModel.hpp
+++ b/modules/vs-compile/src/tm/TimingModel.hpp
@@ -35,7 +35,7 @@ public:
 public:
   void compile();
   string to_string();
-  string to_mzn();
+  int to_mzn(std::ostream &mzn_file, std::ostream &dzn_file);
   string add_operation(Operation op) {
     operations[op.name] = op;
     return op.name;

--- a/modules/vs-compile/src/tm/TimingModel.hpp
+++ b/modules/vs-compile/src/tm/TimingModel.hpp
@@ -35,7 +35,8 @@ public:
 public:
   void compile();
   string to_string();
-  int to_mzn(std::ostream &mzn_file, std::ostream &dzn_file);
+  int to_mzn(std::ostream &mzn_file, std::ostream &dzn_file,
+             bool allow_act_mode_2 = false);
   string add_operation(Operation op) {
     operations[op.name] = op;
     return op.name;

--- a/modules/vs-compile/src/util/Common.hpp
+++ b/modules/vs-compile/src/util/Common.hpp
@@ -45,13 +45,13 @@
 
 #define __NOT_IMPLEMENTED__                                                    \
   LOG(FATAL) << "Function has not been implemented yet!";                      \
-  std::exit(-1);
+  std::exit(EXIT_FAILURE);
 #define __NOT_SUPPORTED__ LOG(FATAL) << "Function is not supported!";
 #define __DEPRECATED__                                                         \
   LOG(WARNING) << "Function is deprecated and will be removed soon!";
 #define __VIRTUAL_FUNCTION__                                                   \
   LOG(FATAL) << "Virtual function cannot be directly accessed!";               \
-  std::exit(-1);
+  std::exit(EXIT_FAILURE);
 
 namespace vesyla {
 namespace util {

--- a/modules/vs-compile/src/util/SysPath.cpp
+++ b/modules/vs-compile/src/util/SysPath.cpp
@@ -29,7 +29,7 @@ string SysPath::curr_dir() {
   }
   if (!glv.gets("__CURR_DIR__", curr_dir)) {
     LOG_FATAL << "Current directory is not set!";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   return curr_dir;
 }
@@ -42,7 +42,7 @@ string SysPath::home_dir() {
   }
   if (!glv.gets("__HOME_DIR__", home_dir)) {
     LOG_FATAL << "Home directory is not set!";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   return home_dir;
 }
@@ -55,7 +55,7 @@ string SysPath::temp_dir() {
   }
   if (!glv.gets("__TEMP_DIR__", temp_dir)) {
     LOG_FATAL << "Temporary directory is not set!";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   return temp_dir;
 }
@@ -68,7 +68,7 @@ string SysPath::prog_dir() {
   }
   if (!glv.gets("__PROG_DIR__", prog_dir)) {
     LOG_FATAL << "Program directory is not set!";
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
   }
   return prog_dir;
 }


### PR DESCRIPTION
# feat(vs-compile): activation modes and scheduling refactor

## Description

This pull request introduces significant changes on the scheduling and instruction generation for the different activation modes. The key changes are: (1) the handling of the constraints to enable the scheduling for activation modes 1 and 2, in addition to existing mode 0 (which was also changed); (2) the creation of activation instruction to prepare support for mode 2.

### Scheduling: Minizinc logic changes
* Replaced the manually added constraints for activation mode 0 and 1 by constraint programming implemented directly in the minizinc `.mzn` file with the following logic:
  * ACT mode 0:
    ```minizinc
    constraint if use_act_mode_0 then
       forall(i, j in 0..NUM_OPS-1 where i < j) (
            (op_slot[i] != op_slot[j] /\ op_cell_row[i] == op_cell_row[j] /\ op_cell_col[i] == op_cell_col[j]) -> (
              (abs(op_slot[i] - op_slot[j]) >= 4) -> (op_start_vec[i] != op_start_vec[j])
            )
         )
    endif;
    ```
  * ACT mode 1:
    ```minizinc
    constraint if use_act_mode_1 then
      % for all operations
      forall(i, j in 0..NUM_OPS-1 where i < j) (
        % if two operations start at the same time, are in the same cell,
        % and are in different slots
        (op_start_vec[i] == op_start_vec[j] /\
         op_cell_row[i] == op_cell_row[j] /\
         op_cell_col[i] == op_cell_col[j] /\
         op_slot[i] != op_slot[j]) -> (
          % for each port P
          forall(P in 0..NUM_PORTS_PER_RESOURCE-1) (
            % the operations must use the same port P
            (exists(k in 0..NUM_OPS-1) (
              op_start_vec[k] == op_start_vec[i] /\
              op_cell_row[k] == op_cell_row[i] /\
              op_cell_col[k] == op_cell_col[i] /\
              op_slot[k] == op_slot[i] /\
              op_port[k] == P
            )) <-> (exists(m in 0..NUM_OPS-1) (
              op_start_vec[m] == op_start_vec[j] /\
              op_cell_row[m] == op_cell_row[j] /\
              op_cell_col[m] == op_cell_col[j] /\
              op_slot[m] == op_slot[j] /\
              op_port[m] == P
            ))
          )
        )
      )
    endif;
    ```
* Introduced a `.dzn` minizinc data file to provide more info on the scheduled operations to the solver: row (`op_cell_row`), column (`op_cell_col`), slot (`op_slot`) and port numbers (`op_port`) [[1]](https://github.com/silagokth/vesyla/pull/107/files#diff-62e4ab7f386ef65eae0372ef5c8a7290f9412cd869694a13f375080358f96719R52-R84)
  * Added `col`, `row`, `slot`, and `port` fields to the `Operation` class to enable populating the `.dzn` file [[2]](https://github.com/silagokth/vesyla/pull/107/files#diff-b66e001222cdc89ca3296b82eb196baa38aaeb94835b78431bffec2cc939e39cR31-R35)
  * Updated the ScheduleEpochPassRewriter to populate these new fields when adding operations to the model [[3]](https://github.com/silagokth/vesyla/pull/107/files#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceR1201-R1207)
* If neither of the constraints for mode 0 or mode 1 can be solved, the solver will relax all of the activation constraints and try to solve only the built-in constraints. This way, we can prepare the activation vectors to use activation mode 2 [[4]](https://github.com/silagokth/vesyla/pull/107/files#diff-1ed0d2509cc477b14c4aa2d91e9187c805c7b6cc0c99137c4634b44ea4419677R170-R203)
* Modularized the MiniZinc solver workflow with new helper functions (`write_minizinc_files`, `run_minizinc`, `turn_to_valid_json`, `check_mzn_solution_valid`) to improve readability and error handling [[5]](https://github.com/silagokth/vesyla/pull/107/files#diff-1ed0d2509cc477b14c4aa2d91e9187c805c7b6cc0c99137c4634b44ea4419677R19-R168)

### Enhancements to Activation Instruction Generation:
* Refactored `create_act_instr` into three distinct methods (`create_act_0_instr`, `create_act_1_instr`, `create_act_2_instr`) to handle different activation modes. Each method now returns an `std::optional` to indicate success or failure [[6]](https://github.com/silagokth/vesyla/pull/107/files#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceR32-R107)
  * If none of the activation modes work, the program fails [[7]](https://github.com/silagokth/vesyla/pull/107/files#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceR122-R146)

### Miscellaneous Enhancements:
* Added constants (`MAX_SLOTS`, `NUM_PORTS_PER_RESOURCE`, `MAX_LATENCY`) in `TimingModel` for better configurability [[8]](https://github.com/silagokth/vesyla/pull/107/files#diff-62e4ab7f386ef65eae0372ef5c8a7290f9412cd869694a13f375080358f96719R1-R6)
* Updated the `to_mzn` method in `TimingModel` to accept output streams for better flexibility in file handling [[9]](https://github.com/silagokth/vesyla/pull/107/files#diff-62e4ab7f386ef65eae0372ef5c8a7290f9412cd869694a13f375080358f96719R34-R35)
* Replaced `std::exit(-1)` with `std::exit(EXIT_FAILURE)` in many CPP files of `vs-compile`

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Current `drra-tests` still pass. However, they do not cover activation mode 1 or activation mode 2. This should be addressed. Ref https://github.com/silagokth/drra-tests/issues/9
- Created a `dot_32_1cell` example in https://github.com/silagokth/drra-tests/tree/dot_32_1cell which does not work with activation modes 0 or 1. This forces the code to go all the way to mode 2, this enables us to test the soundness of the scheduling logic beyond mode 0. However, this test cannot pass now as we didn't implement mode 2 in SST or RTL, yet.

**Test Configuration**:

- OS: Ubuntu 24.04
- [drra-components](https://github.com/silagokth/drra-components): v2.6.2
- Other experimental setup details: https://github.com/silagokth/drra-tests/tree/dot_32_1cell

## Checklist
- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules