### PR TITLE
fix(vs-testcase): fixed template stored inside vesyla to generate an example drra-test

### DIFF
--- a/modules/vs-testcase/template/drra/arch.json
+++ b/modules/vs-testcase/template/drra/arch.json
@@ -31,15 +31,33 @@
   "cells": [
     {
       "name": "cell_top_impl",
-      "kind": "cell_top"
+      "kind": "cell_top",
+      "controller": "sequencer_impl",
+      "resource_list": [
+        "swb_impl",
+        "iosram_top_impl"
+      ]
     },
     {
       "name": "cell_mid_impl",
-      "kind": "cell_mid"
+      "kind": "cell_mid",
+      "controller": "sequencer_impl",
+      "resource_list": [
+        "swb_impl",
+        "rf_impl",
+        "rf_impl",
+        "rf_impl",
+        "dpu_impl"
+      ]
     },
     {
       "name": "cell_btm_impl",
-      "kind": "cell_btm"
+      "kind": "cell_btm",
+      "controller": "sequencer_impl",
+      "resource_list": [
+        "swb_impl",
+        "iosram_btm_impl"
+      ]
     }
   ],
   "fabric": {


### PR DESCRIPTION
# fix(vs-testcase): fixed template stored inside vesyla to generate an example drra-test

## Description

This PR fixed the arch.json contained in the template DRRA test as it is currently not working when following the tutorial in https://silago.eecs.kth.se/docs/ToolChain/Vesyla/Tutorials/Tutorial_DRRA/ 

### Type of change
- Bug fix (non-breaking change which fixes an issue)
