### PR TITLE
fix(vs-compile): fixed timing schedule issue

### DIFF
--- a/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
+++ b/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
@@ -894,7 +894,8 @@ private:
       attempts++;
       if (attempts > max_attempts) {
         llvm::outs() << "Error: Too many attempts to allocate registers for "
-                        "ACT mode 2 prep instructions at cycle " << cycle << ".\n";
+                        "ACT mode 2 prep instructions at cycle "
+                     << cycle << ".\n";
         exit(EXIT_FAILURE);
       }
       if (cell_time_table.find(cycle) != cell_time_table.end()) {
@@ -1256,6 +1257,7 @@ private:
     min_shift_time = -min_shift_time;
     llvm::outs() << "Min shift time: " << min_shift_time << "\n";
     total_latency = total_latency + min_shift_time;
+    llvm::outs() << "Total latency after shifting: " << total_latency << "\n";
 
     // shift the time table
     for (auto it = time_table.begin(); it != time_table.end(); ++it) {
@@ -1281,7 +1283,7 @@ private:
                   return a.first < b.first;
                 });
 
-      int prev_t = 0;
+      int prev_t = -1;
       std::vector<std::pair<int, mlir::Operation *>> new_time_op_vec;
       if (time_op_vec.size() > 0) {
         // start from the smallest time, insert the WAIT instructions if
@@ -1291,7 +1293,7 @@ private:
           if (curr_t - prev_t > 1) {
             // create a WAIT instruction
             rewriter.setInsertionPointToEnd(block);
-            auto wait_instr_param_map = create_wait_instr(curr_t - prev_t - 1);
+            auto wait_instr_param_map = create_wait_instr(curr_t - prev_t - 2);
             mlir::StringAttr id = rewriter.getStringAttr(
                 vesyla::util::Common::gen_random_string(8));
             mlir::StringAttr type = rewriter.getStringAttr("wait");

--- a/modules/vs-testcase/template/drra/run.sh
+++ b/modules/vs-testcase/template/drra/run.sh
@@ -169,11 +169,13 @@ stop_spinner 0
 start_spinner
 printf "  ${BLUE}Verifying${NC} (mem/sram_image_m0.bin)"
 if [ ! -f "mem/sram_image_m0.bin" ]; then
+  stop_spinner 1
   printf " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin not found!"
   exit 1
 fi
 ## Check that the output is not empty
 if [ ! -s "mem/sram_image_m0.bin" ]; then
+  stop_spinner 1
   printf " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin is empty!"
   exit 1
 fi
@@ -217,6 +219,7 @@ sort -n mem/sram_image_m2.bin -o mem/sram_image_m2.bin
 set +e
 error_output=$(diff -q mem/sram_image_m0.bin mem/sram_image_m2.bin 2>&1)
 if [ $? -ne 0 ]; then
+  stop_spinner 1
   printf " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin and mem/sram_image_m2.bin differ!"
   printf "${RED}Error details:${NC}"
   echo "$error_output"
@@ -248,6 +251,7 @@ sort -n mem/sram_image_m3.bin -o mem/sram_image_m3.bin # Reorder the memory file
 set +e
 error_output=$(diff -q mem/sram_image_m0.bin mem/sram_image_m3.bin 2>&1)
 if [ $? -ne 0 ]; then
+  stop_spinner 1
   printf " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin and mem/sram_image_m3.bin differ!"
   printf "${RED}Error details:${NC}"
   echo "$error_output"


### PR DESCRIPTION
# fix(vs-compile): fixed timing schedule issue

## Description

This pull request introduces several improvements to error handling and output messaging in both the `ScheduleEpochPassRewriter` C++ class and the DRRA test case shell script. The changes enhance debugging capabilities and ensure that errors are more clearly reported to the user.

**C++ scheduling logic improvements:**

* Improved error message formatting for register allocation failures in `ScheduleEpochPassRewriter` to make the output more readable.
* Added a debug message to print the updated `total_latency` after time shifting, aiding in debugging scheduling issues.
* Changed the initial value of `prev_t` from `0` to `-1` to correctly handle time intervals when inserting WAIT instructions.
* Adjusted the calculation for WAIT instruction parameters to subtract an additional cycle, ensuring correct instruction timing.

**Shell script error handling enhancements:**

* Added calls to `stop_spinner 1` before error exits in `run.sh` to ensure the spinner is properly stopped when errors are encountered, improving user feedback and script robustness. [[1]](diffhunk://#diff-4e700ea61cc2164c5d2d99dfd368b92c28e4f234abad599ebebbcbec70b975b8R172-R178) [[2]](diffhunk://#diff-4e700ea61cc2164c5d2d99dfd368b92c28e4f234abad599ebebbcbec70b975b8R222) [[3]](diffhunk://#diff-4e700ea61cc2164c5d2d99dfd368b92c28e4f234abad599ebebbcbec70b975b8R254)

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
